### PR TITLE
Modifies listvector print to include count file info

### DIFF
--- a/clustercommand.cpp
+++ b/clustercommand.cpp
@@ -309,6 +309,7 @@ int ClusterCommand::execute(){
 		
 		NameAssignment* nameMap = NULL;
         CountTable* ct = NULL;
+        map<string, int> counts;
 		if(namefile != ""){	
 			nameMap = new NameAssignment(namefile);
 			nameMap->readMap();
@@ -317,6 +318,7 @@ int ClusterCommand::execute(){
             ct = new CountTable();
             ct->readTable(countfile, false, false);
             read->read(ct);
+            counts = ct->getNameMap();
         }else { read->read(nameMap); }
 		
 		list = read->getListVector();
@@ -403,10 +405,10 @@ int ClusterCommand::execute(){
 			}
 
 			if(previousDist <= 0.0000 && dist != previousDist){
-				printData("unique");
+				printData("unique", counts);
 			}
 			else if(rndDist != rndPreviousDist){
-				printData(toString(rndPreviousDist,  length-1));
+				printData(toString(rndPreviousDist,  length-1), counts);
 			}
 		
 			previousDist = dist;
@@ -423,10 +425,10 @@ int ClusterCommand::execute(){
 		}
 		
 		if(previousDist <= 0.0000){
-			printData("unique");
+			printData("unique", counts);
 		}
 		else if(rndPreviousDist<cutoff){
-			printData(toString(rndPreviousDist, length-1));
+			printData(toString(rndPreviousDist, length-1), counts);
 		}
 		
 		delete matrix;
@@ -486,7 +488,7 @@ int ClusterCommand::execute(){
 
 //**********************************************************************************************************************
 
-void ClusterCommand::printData(string label){
+void ClusterCommand::printData(string label, map<string, int>& counts){
 	try {
 		if (m->isTrue(timing)) {
 			m->mothurOut("\tTime: " + toString(time(NULL) - start) + "\tsecs for " + toString(oldRAbund.getNumBins()) 
@@ -507,7 +509,11 @@ void ClusterCommand::printData(string label){
         }
         
 		oldList.setLabel(label);
-		oldList.print(listFile);
+        if(countfile != "") {
+            oldList.print(listFile, counts);
+        }else {
+            oldList.print(listFile);
+        }
 	}
 	catch(exception& e) {
 		m->errorOut(e, "ClusterCommand", "printData");

--- a/clustercommand.h
+++ b/clustercommand.h
@@ -65,7 +65,7 @@ private:
 	time_t start;
 	unsigned long loops;
 	
-	void printData(string label);
+	void printData(string label, map<string, int>&);
 	vector<string> outputNames;
     
     int createRabund(CountTable*&, ListVector*&, RAbundVector*&);

--- a/clusterdoturcommand.cpp
+++ b/clusterdoturcommand.cpp
@@ -219,6 +219,7 @@ int ClusterDoturCommand::execute(){
         
         NameAssignment* nameMap = NULL;
         CountTable* ct = NULL;
+        map<string, int> counts;
         if(namefile != "") {	
 			nameMap = new NameAssignment(namefile);
 			nameMap->readMap();
@@ -228,6 +229,7 @@ int ClusterDoturCommand::execute(){
             ct = new CountTable();
             ct->readTable(countfile, false, false);
             cluster->readPhylipFile(phylipfile, ct);
+            counts = ct->getNameMap();
             delete ct;
         }else {
             cluster->readPhylipFile(phylipfile, nameMap);
@@ -285,10 +287,10 @@ int ClusterDoturCommand::execute(){
 			}
 
 			if(previousDist <= 0.0000 && dist != previousDist){
-				printData("unique");
+				printData("unique", counts);
 			}
 			else if(rndDist != rndPreviousDist){
-				printData(toString(rndPreviousDist,  length-1));
+				printData(toString(rndPreviousDist,  length-1), counts);
 			}
 		
 			previousDist = dist;
@@ -298,10 +300,10 @@ int ClusterDoturCommand::execute(){
 		}
 	
 		if(previousDist <= 0.0000){
-			printData("unique");
+			printData("unique", counts);
 		}
 		else if(rndPreviousDist<cutoff){
-			printData(toString(rndPreviousDist, length-1));
+			printData(toString(rndPreviousDist, length-1), counts);
 		}
 		
         if (countfile == "") {
@@ -348,7 +350,7 @@ int ClusterDoturCommand::execute(){
 
 //**********************************************************************************************************************
 
-void ClusterDoturCommand::printData(string label){
+void ClusterDoturCommand::printData(string label, map<string, int>& counts){
 	try {
         oldRAbund.setLabel(label);
         if (countfile == "") {
@@ -359,7 +361,13 @@ void ClusterDoturCommand::printData(string label){
 		oldRAbund.getSAbundVector().print(cout);
 		
 		oldList.setLabel(label);
-		oldList.print(listFile);
+        
+        if(countfile != "") {
+            oldList.print(listFile, counts);
+        }else {
+            oldList.print(listFile);
+        }
+
 	}
 	catch(exception& e) {
 		m->errorOut(e, "ClusterDoturCommand", "printData");

--- a/clusterdoturcommand.h
+++ b/clusterdoturcommand.h
@@ -48,7 +48,7 @@ private:
 	RAbundVector oldRAbund;
 	ListVector oldList;
 	
-	void printData(string label);
+	void printData(string label, map<string, int>&);
 	vector<string> outputNames;
 };
 

--- a/clustersplitcommand.cpp
+++ b/clustersplitcommand.cpp
@@ -892,13 +892,19 @@ int ClusterSplitCommand::mergeLists(vector<string> listNames, map<float, int> us
         if (countfile != "") { variables["[tag2]"] = "unique_list"; }
         string listFileName = getOutputFileName("list", variables);
         
+        map<string, int> counts;
         if (countfile == "") {
             m->openOutputFile(sabundFileName,	outSabund);
             m->openOutputFile(rabundFileName,	outRabund);
             outputNames.push_back(sabundFileName); outputTypes["sabund"].push_back(sabundFileName);
             outputNames.push_back(rabundFileName); outputTypes["rabund"].push_back(rabundFileName);
             
+        }else {
+            CountTable ct;
+            ct.readTable(countfile, false, false);
+            counts = ct.getNameMap();
         }
+        
 		m->openOutputFile(listFileName,	outList);
         outputNames.push_back(listFileName); outputTypes["list"].push_back(listFileName);
 		
@@ -961,9 +967,9 @@ int ClusterSplitCommand::mergeLists(vector<string> listNames, map<float, int> us
                 rabund->print(outRabund);
             }
 			//outList << endl;
-            if (!m->printedListHeaders) { 
-                m->listBinLabelsInFile.clear(); completeList.printHeaders(outList); }
-            completeList.print(outList);
+            if (!m->printedListHeaders) { m->listBinLabelsInFile.clear(); completeList.printHeaders(outList); }
+            if (countfile == "") { completeList.print(outList); }
+            else { completeList.print(outList, counts);   }
 			
 			if (rabund != NULL) { delete rabund; }
 		}

--- a/countgroupscommand.cpp
+++ b/countgroupscommand.cpp
@@ -289,8 +289,8 @@ int CountGroupsCommand::execute(){
 			
             map<string, string> variables; 
             string thisOutputDir = outputDir;
-            if (outputDir == "") {  thisOutputDir += m->hasPath(countfile);  }
-            variables["[filename]"] = thisOutputDir + m->getRootName(m->getSimpleName(countfile));
+            if (outputDir == "") {  thisOutputDir += m->hasPath(sharedfile);  }
+            variables["[filename]"] = thisOutputDir + m->getRootName(m->getSimpleName(sharedfile));
             string outputFileName = getOutputFileName("summary", variables);
             outputNames.push_back(outputFileName); outputTypes["summary"].push_back(outputFileName);
             ofstream out;

--- a/datavector.hpp
+++ b/datavector.hpp
@@ -35,7 +35,8 @@ public:
 	
 	virtual void resize(int) = 0;
 	virtual int size()	= 0;
-	virtual void print(ostream&) = 0;
+	virtual void print(ostream&);
+    virtual void print(ostream&, map<string, int>&) {}
 	virtual void printHeaders(ostream&) {};
 	virtual void clear() = 0;
 	

--- a/listvector.cpp
+++ b/listvector.cpp
@@ -33,7 +33,18 @@ inline bool abundNamesSort(string left, string right){
         return true;
     }
     return false;	
+}
+//sorts highest to lowest
+/***********************************************************************/
+inline bool abundNamesSort2(listCt left, listCt right){
+    if (left.bin == "") { return false; }
+    if (right.bin == "") { return true; }
+    if (left.binSize > right.binSize) {
+        return true;
+    }
+    return false;
 } 
+
 
 /***********************************************************************/
 
@@ -283,19 +294,37 @@ void ListVector::printHeaders(ostream& output){
 
 /***********************************************************************/
 
-void ListVector::print(ostream& output){
+void ListVector::print(ostream& output, map<string, int>& ct){
 	try {
 		output << label << '\t' << numBins << '\t';
 	
-        vector<string> hold = data;
-        sort(hold.begin(), hold.end(), abundNamesSort);
         
-		for(int i=0;i<hold.size();i++){
-			if(hold[i] != ""){
-				output << hold[i] << '\t';
+        vector<listCt> hold;
+        for (int i = 0; i < data.size(); i++) {
+            if (data[i] != "") {
+                vector<string> binNames;
+                string bin = data[i];
+                m->splitAtComma(bin, binNames);
+                int total = 0;
+                for (int j = 0; j < binNames.size(); j++) {
+                    map<string, int>::iterator it = ct.find(binNames[j]);
+                    if (it == ct.end()) {
+                        m->mothurOut("[ERROR]: " + binNames[j] + " is not in your count table. Please correct.\n"); m->control_pressed = true;
+                    }else { total += ct[binNames[j]]; }
+                }
+                listCt temp(data[i], total);
+                hold.push_back(temp);
             }
-		}
-		output << endl;
+        }
+        sort(hold.begin(), hold.end(), abundNamesSort2);
+        
+        for(int i=0;i<hold.size();i++){
+            if(hold[i].bin != ""){
+                output << hold[i].bin << '\t';
+            }
+        }
+        output << endl;
+        
 	}
 	catch(exception& e) {
 		m->errorOut(e, "ListVector", "print");
@@ -303,6 +332,27 @@ void ListVector::print(ostream& output){
 	}
 }
 
+/***********************************************************************/
+
+void ListVector::print(ostream& output){
+    try {
+        output << label << '\t' << numBins << '\t';
+        
+        vector<string> hold = data;
+        sort(hold.begin(), hold.end(), abundNamesSort);
+        
+        for(int i=0;i<hold.size();i++){
+            if(hold[i] != ""){
+                output << hold[i] << '\t';
+            }
+        }
+        output << endl;
+    }
+    catch(exception& e) {
+        m->errorOut(e, "ListVector", "print");
+        exit(1);
+    }
+}
 
 /***********************************************************************/
 

--- a/listvector.hpp
+++ b/listvector.hpp
@@ -36,7 +36,8 @@ public:
 	void resize(int);
 	void clear();
 	int size();
-	void print(ostream&);
+    void print(ostream&);
+	void print(ostream&, map<string, int>&);
     void printHeaders(ostream&);
 	
 	RAbundVector getRAbundVector();

--- a/mgclustercommand.cpp
+++ b/mgclustercommand.cpp
@@ -235,6 +235,7 @@ int MGClusterCommand::execute(){
 		if (abort == true) { if (calledHelp) { return 0; }  return 2;	}
 		
 		//read names file
+        map<string, int> counts;
 		if (namefile != "") {
 			nameMap = new NameAssignment(namefile);
 			nameMap->readMap();
@@ -244,6 +245,7 @@ int MGClusterCommand::execute(){
             nameMap= new NameAssignment();
             vector<string> tempNames = ct->getNamesOfSeqs();
             for (int i = 0; i < tempNames.size(); i++) {  nameMap->push_back(tempNames[i]);  }
+            counts = ct->getNameMap();
         }else{ nameMap= new NameAssignment(); }
 		
 		string fileroot = outputDir + m->getRootName(m->getSimpleName(blastfile));
@@ -352,7 +354,7 @@ int MGClusterCommand::execute(){
 				
 				if(previousDist <= 0.0000 && dist != previousDist){
 					oldList.setLabel("unique");
-					printData(&oldList);
+					printData(&oldList, counts);
 				}
 				else if(rndDist != rndPreviousDist){
 					if (merge) {
@@ -366,11 +368,11 @@ int MGClusterCommand::execute(){
 						}
 						
 						temp->setLabel(toString(rndPreviousDist,  precisionLength-1));
-						printData(temp);
+						printData(temp, counts);
 						delete temp;
 					}else{
 						oldList.setLabel(toString(rndPreviousDist,  precisionLength-1));
-						printData(&oldList);
+						printData(&oldList, counts);
 					}
 				}
 	
@@ -383,7 +385,7 @@ int MGClusterCommand::execute(){
 			
 			if(previousDist <= 0.0000){
 				oldList.setLabel("unique");
-				printData(&oldList);
+				printData(&oldList, counts);
 			}
 			else if(rndPreviousDist<cutoff){
 				if (merge) {
@@ -397,11 +399,11 @@ int MGClusterCommand::execute(){
 					}
 					
 					temp->setLabel(toString(rndPreviousDist,  precisionLength-1));
-					printData(temp);
+					printData(temp, counts);
 					delete temp;
 				}else{
 					oldList.setLabel(toString(rndPreviousDist,  precisionLength-1));
-					printData(&oldList);
+					printData(&oldList, counts);
 				}
 			}
 			
@@ -485,7 +487,7 @@ int MGClusterCommand::execute(){
 												
 						if((previousDist <= 0.0000) && (seqs[i].dist != previousDist)){
 							oldList.setLabel("unique");
-							printData(&oldList);
+							printData(&oldList, counts);
 						}
 						else if((rndDist != rndPreviousDist)){
 							if (merge) {
@@ -501,11 +503,11 @@ int MGClusterCommand::execute(){
 								}
 
 								temp->setLabel(toString(rndPreviousDist,  precisionLength-1));
-								printData(temp);
+								printData(temp, counts);
 								delete temp;
 							}else{
 								oldList.setLabel(toString(rndPreviousDist,  precisionLength-1));
-								printData(&oldList);
+								printData(&oldList, counts);
 							}
 						}
 						
@@ -521,7 +523,7 @@ int MGClusterCommand::execute(){
 			
 			if(previousDist <= 0.0000){
 				oldList.setLabel("unique");
-				printData(&oldList);
+				printData(&oldList, counts);
 			}
 			else if(rndPreviousDist<cutoff){
 				if (merge) {
@@ -537,11 +539,11 @@ int MGClusterCommand::execute(){
 					}
 					
 					temp->setLabel(toString(rndPreviousDist,  precisionLength-1));
-					printData(temp);
+					printData(temp, counts);
 					delete temp;
 				}else{
 					oldList.setLabel(toString(rndPreviousDist,  precisionLength-1));
-					printData(&oldList);
+					printData(&oldList, counts);
 				}
 			}
 			
@@ -610,9 +612,12 @@ int MGClusterCommand::execute(){
 	}
 }
 //**********************************************************************************************************************
-void MGClusterCommand::printData(ListVector* mergedList){
+void MGClusterCommand::printData(ListVector* mergedList, map<string, int>& counts){
 	try {
-		mergedList->print(listFile);
+        if (countfile != "") {
+            mergedList->print(listFile, counts);
+        }else { mergedList->print(listFile); }
+        
         SAbundVector sabund = mergedList->getSAbundVector();
         
         if (countfile == "") {

--- a/mgclustercommand.h
+++ b/mgclustercommand.h
@@ -60,7 +60,7 @@ private:
 	int precision, length, precisionLength;
 	bool abort, minWanted, hclusterWanted, merge, hard, cutoffSet;
 	
-	void printData(ListVector*);
+	void printData(ListVector*, map<string, int>&);
 	ListVector* mergeOPFs(map<string, int>, float);
 	void sortHclusterFiles(string, string);
 	vector<seqDist> getSeqs(ifstream&);

--- a/mothur.h
+++ b/mothur.h
@@ -182,6 +182,13 @@ struct consTax{
 	consTax(string n, string t, int a) :  name(n), taxonomy(t), abundance(a) {}
 };
 /***********************************************************************/
+struct listCt{
+    string bin;
+    int binSize;
+    listCt() :  bin(""), binSize(0) {};
+    listCt(string b, int a) :  bin(b), binSize(a) {}
+};
+/***********************************************************************/
 struct consTax2{
     string taxonomy;
     int abundance;

--- a/phylotypecommand.cpp
+++ b/phylotypecommand.cpp
@@ -12,6 +12,7 @@
 #include "listvector.hpp"
 #include "rabundvector.hpp"
 #include "sabundvector.hpp"
+#include "counttable.h"
 
 //**********************************************************************************************************************
 vector<string> PhylotypeCommand::setParameters(){	
@@ -238,12 +239,17 @@ int PhylotypeCommand::execute(){
         if (countfile != "") { variables["[tag2]"] = "unique_list"; }
         string listFileName = getOutputFileName("list", variables);
         
+        map<string, int> counts;
         if (countfile == "") {
             m->openOutputFile(sabundFileName,	outSabund);
             m->openOutputFile(rabundFileName,	outRabund);
             outputNames.push_back(sabundFileName); outputTypes["sabund"].push_back(sabundFileName);
             outputNames.push_back(rabundFileName); outputTypes["rabund"].push_back(rabundFileName);
             
+        }else {
+            CountTable ct;
+            ct.readTable(countfile, false, false);
+            counts = ct.getNameMap();
         }
 		m->openOutputFile(listFileName,	outList);
         outputNames.push_back(listFileName); outputTypes["list"].push_back(listFileName);
@@ -304,7 +310,8 @@ int PhylotypeCommand::execute(){
 				
 				//print listvector
                 if (!m->printedListHeaders) { list.printHeaders(outList); }
-                list.print(outList);
+                if (countfile == "") { list.print(outList);  }
+                else { list.print(outList, counts);  }
                 
                 if (countfile == "") {
                     //print rabund


### PR DESCRIPTION
This change only effects cluster commands.
All the *.pick commands need to preserve the otuLabel order so no change to those commands.

Bug Fix: Otu not printed by abundance.
Completes: Issue #44, Issue #11.