### PR TITLE
Adds default file location in engine

### DIFF
--- a/source/engine.cpp
+++ b/source/engine.cpp
@@ -38,6 +38,14 @@ InteractEngine::InteractEngine(string path){
 	if (temppath == "") { path = mout->findProgramPath("mothur"); }
 	
 	mout->argv = path;
+
+    //if you haven't set your own location
+    #ifdef MOTHUR_FILES
+    #else
+        //set default location to search for files to mothur's executable location.  This will resolve issue of double-clicking on the executable which opens mothur and sets pwd to your home directory instead of the mothur directory and leads to "unable to find file" errors.
+        string tempDefault = path.substr(0, (path.find_last_of('m')));
+        mout->setDefaultPath(tempDefault);
+    #endif
 }
 
 /***********************************************************************/
@@ -210,6 +218,15 @@ BatchEngine::BatchEngine(string path, string batchFileName){
 		if (temppath == "") { path = mout->findProgramPath("mothur"); }
 		
 		mout->argv = path;
+        
+        //if you haven't set your own location
+#ifdef MOTHUR_FILES
+#else
+        //set default location to search for files to mothur's executable location.  This will resolve issue of double-clicking on the executable which opens mothur and sets pwd to your home directory instead of the mothur directory and leads to "unable to find file" errors.
+        string tempDefault = path.substr(0, (path.find_last_of('m')));
+        mout->setDefaultPath(tempDefault);
+#endif
+
 				
 	}
 	catch(exception& e) {
@@ -380,6 +397,15 @@ ScriptEngine::ScriptEngine(string path, string commandString){
 		if (temppath == "") { path = mout->findProgramPath("mothur"); }
 		
 		mout->argv = path;
+        
+        //if you haven't set your own location
+#ifdef MOTHUR_FILES
+#else
+        //set default location to search for files to mothur's executable location.  This will resolve issue of double-clicking on the executable which opens mothur and sets pwd to your home directory instead of the mothur directory and leads to "unable to find file" errors.
+        string tempDefault = path.substr(0, (path.find_last_of('m')));
+        mout->setDefaultPath(tempDefault);
+#endif
+
 				
 	}
 	catch(exception& e) {


### PR DESCRIPTION
This will resolve issue of double-clicking on the executable which opens mothur and sets pwd to your home directory instead of the mothur directory and leads to "unable to find file" errors.

Issue #119