### PR TITLE
Confidence score Issue #192

### DIFF
--- a/source/read/splitmatrix.cpp
+++ b/source/read/splitmatrix.cpp
@@ -223,7 +223,7 @@ int SplitMatrix::createDistanceFilesFromTax(map<string, int>& seqGroup, int numG
             tempDistFiles.push_back(tempDistFile);
         }
         
-        splitNames(seqGroup, numGroups, tempDistFiles);
+        splitNamesTax(seqGroup, numGroups, tempDistFiles);
         
 		if (m->control_pressed)	 {  for (int i = 0; i < dists.size(); i++) { m->mothurRemove((dists[i].begin()->first)); m->mothurRemove((dists[i].begin()->second)); } dists.clear(); }
 
@@ -309,7 +309,7 @@ int SplitMatrix::splitDistanceFileByTax(map<string, int>& seqGroup, int numGroup
 			}
 		}
 		
-        splitNames(seqGroup, numGroups, tempDistFiles);
+        splitNamesDist(seqGroup, numGroups, tempDistFiles);
         
 		if (m->control_pressed)	 {  
 			for (int i = 0; i < dists.size(); i++) { 
@@ -519,7 +519,7 @@ int SplitMatrix::splitDistanceLarge(){
             }
         }
         
-		splitNames(seqGroup, numGroups, tempDistFiles);
+		splitNamesDist(seqGroup, numGroups, tempDistFiles);
 				
 		return 0;			
 	}
@@ -529,7 +529,7 @@ int SplitMatrix::splitDistanceLarge(){
 	}
 }
 //********************************************************************************************************************
-int SplitMatrix::splitNames(map<string, int>& seqGroup, int numGroups, vector<string>& tempDistFiles){
+int SplitMatrix::splitNamesDist(map<string, int>& seqGroup, int numGroups, vector<string>& tempDistFiles){
 	try {
         ofstream outFile;
         map<string, int>::iterator it;
@@ -631,9 +631,116 @@ int SplitMatrix::splitNames(map<string, int>& seqGroup, int numGroups, vector<st
 		return 0;
 	}
 	catch(exception& e) {
-		m->errorOut(e, "SplitMatrix", "splitNames");
+		m->errorOut(e, "SplitMatrix", "splitNamesDist");
 		exit(1);
 	}
+}
+//********************************************************************************************************************
+int SplitMatrix::splitNamesTax(map<string, int>& seqGroup, int numGroups, vector<string>& tempDistFiles){
+    try {
+        ofstream outFile;
+        map<string, int>::iterator it;
+        
+        string inputFile = namefile;
+        if (countfile != "") { inputFile = countfile; }
+        
+        for(int i=0;i<numGroups;i++){  m->mothurRemove((inputFile + "." + toString(i) + ".temp")); }
+        
+        singleton = inputFile + ".extra.temp";
+        ofstream remainingNames;
+        m->openOutputFile(singleton, remainingNames);
+        
+        bool wroteExtra = false;
+        string errorMessage = "name";
+        
+        ifstream bigNameFile;
+        m->openInputFile(inputFile, bigNameFile);
+        
+        //grab header line
+        string headers = "";
+        if (countfile != "") {  errorMessage = "count"; headers = m->getline(bigNameFile); m->gobble(bigNameFile); }
+        
+        string name, nameList;
+        while(!bigNameFile.eof()){
+            bigNameFile >> name >> nameList;
+            m->getline(bigNameFile); m->gobble(bigNameFile); //extra getline is for rest of countfile line if groups are given.
+            
+            //did this sequence get assigned a group
+            it = seqGroup.find(name);
+            
+            if (it != seqGroup.end()) {
+                m->openOutputFileAppend((inputFile + "." + toString(it->second) + ".temp"), outFile);
+                outFile << name << '\t' << nameList << endl;
+                outFile.close();
+            }else{
+                m->mothurOut("[ERROR]: " + name + " is not assigned to a group.  This indicates a file mismatch likely caused by forgetting to include the " + errorMessage + " file on a remove.seqs or remove.lineage command. Please correct.\n"); m->control_pressed = true;
+            }
+        }
+        bigNameFile.close();
+        
+        for(int i=0;i<numGroups;i++){
+            string tempNameFile = inputFile + "." + toString(i) + ".temp";
+            string tempDistFile = tempDistFiles[i];
+            
+            //if there are valid distances
+            ifstream fileHandle;
+            fileHandle.open(tempDistFile.c_str());
+            if(fileHandle) 	{
+                m->gobble(fileHandle);
+                if (!fileHandle.eof()) {  //check
+                    map<string, string> temp;
+                    if (countfile != "") {
+                        //add header
+                        ofstream out;
+                        string newtempNameFile = tempNameFile + "2";
+                        m->openOutputFile(newtempNameFile, out);
+                        out << "Representative_Sequence\ttotal" << endl;
+                        out.close();
+                        m->appendFiles(tempNameFile, newtempNameFile);
+                        m->mothurRemove(tempNameFile);
+                        m->renameFile(newtempNameFile, tempNameFile);
+                    }
+                    temp[tempDistFile] = tempNameFile;
+                    dists.push_back(temp);
+                }else{
+                    ifstream in;
+                    m->openInputFile(tempNameFile, in);
+                    
+                    while(!in.eof()) {
+                        in >> name >> nameList;  m->gobble(in);
+                        wroteExtra = true;
+                        remainingNames << name << '\t' << nameList << endl;
+                    }
+                    in.close();
+                    m->mothurRemove(tempNameFile);
+                }
+            }
+            fileHandle.close();
+        }
+        
+        remainingNames.close();
+        
+        if (!wroteExtra) {
+            m->mothurRemove(singleton);
+            singleton = "none";
+        }else if (countfile != "") {
+            //add header
+            ofstream out;
+            string newtempNameFile = singleton + "2";
+            m->openOutputFile(newtempNameFile, out);
+            out << "Representative_Sequence\ttotal" << endl;
+            out.close();
+            m->appendFiles(singleton, newtempNameFile);
+            m->mothurRemove(singleton);
+            m->renameFile(newtempNameFile, singleton);
+        }
+        
+        return 0;
+    }
+    catch(exception& e) {
+        m->errorOut(e, "SplitMatrix", "splitNamesTax");
+        exit(1);
+    }
 }
 //********************************************************************************************************************
 int SplitMatrix::splitDistanceRAM(){
@@ -751,7 +858,7 @@ int SplitMatrix::splitDistanceRAM(){
             }
         }
         
-		splitNames(seqGroup, numGroups, tempDistFiles);
+		splitNamesDist(seqGroup, numGroups, tempDistFiles);
 				
 		return 0;			
 	}

--- a/source/read/splitmatrix.h
+++ b/source/read/splitmatrix.h
@@ -40,7 +40,8 @@ class SplitMatrix  {
 		int splitClassify();
 		int splitDistanceLarge();
 		int splitDistanceRAM();
-		int splitNames(map<string, int>& groups, int, vector<string>&);
+		int splitNamesDist(map<string, int>& groups, int, vector<string>&);
+        int splitNamesTax(map<string, int>& groups, int, vector<string>&);
 		int splitDistanceFileByTax(map<string, int>&, int);
 		int createDistanceFilesFromTax(map<string, int>&, int);
 };


### PR DESCRIPTION
Count and Name files were allowed to include names not in fasta file. This occurred if user failed to remove chimeras or contaminants by leaving the name or count file off of the remove.seqs or remove.lineage commands.  Not removing the chimeras from the count or name file allows them to be added to the list file because mothur creates the "unique" list from those names.  This fix is designed to make it harder for people to make clustering mistakes that could seriously effect their results because it 3am and they forgot to include a file on remove.seqs and ignored a few the error messages along the way.  We build the "unique" list based on the count or names file to accommodate the sparse distance matrix where sequences may be present in the names or count file, but absent from the distance matrix because their distances are above the cutoff.

#190