### PR TITLE
Strip whitespace from command arguments.

### DIFF
--- a/source/optionparser.cpp
+++ b/source/optionparser.cpp
@@ -23,6 +23,8 @@ OptionParser::OptionParser(string option) {
 				m->splitAtEquals(key, value);
 				if ((key == "candidate") || (key == "query")) { key = "fasta"; }
 				if (key == "template") { key = "reference"; }
+				key = m->splitWhiteSpace(key).front();
+			    value = m->splitWhiteSpace(value).front();
 				parameters[key] = value;
 			}
 			
@@ -30,6 +32,8 @@ OptionParser::OptionParser(string option) {
 			m->splitAtEquals(key, option);
 			if ((key == "candidate") || (key == "query")) { key = "fasta"; }
 			if (key == "template") { key = "reference"; }
+            key = m->splitWhiteSpace(key).front();
+			option = m->splitWhiteSpace(option).front();
 			parameters[key] = option;
 		}
 	}
@@ -52,6 +56,8 @@ OptionParser::OptionParser(string option, map<string, string>& copy) {
 				m->splitAtEquals(key, value);
 				if ((key == "candidate") || (key == "query")) { key = "fasta"; }
 				if (key == "template") { key = "reference"; }
+				key = m->splitWhiteSpace(key).front();
+			    value = m->splitWhiteSpace(value).front();
 				parameters[key] = value;
 			}
 			
@@ -59,6 +65,8 @@ OptionParser::OptionParser(string option, map<string, string>& copy) {
 			m->splitAtEquals(key, option);
 			if ((key == "candidate") || (key == "query")) { key = "fasta"; }
 			if (key == "template") { key = "reference"; }
+			key = m->splitWhiteSpace(key).front();
+			option = m->splitWhiteSpace(option).front();
 			parameters[key] = option;
 		}
         


### PR DESCRIPTION
This pull request address issue #191 whereby extraneous whitespace in command arguments leads to errors.

To address this I have implemented the already existing splitWhiteSpace function from mothurout in optionparser to strip leading and trailing whitespace from the input. A logfile showing these changes at work is available [here](http://pastebin.com/1kAVJpSj).