### PR TITLE
Fix Absolute Paths in Xcode

### DIFF
--- a/Mothur.xcodeproj/project.pbxproj
+++ b/Mothur.xcodeproj/project.pbxproj
@@ -1785,8 +1785,7 @@
 				83F25B0B163B031200ABE73D /* forest.h */,
 			);
 			name = randomforest;
-			path = /Users/sarahwestcott/Desktop/mothur;
-			sourceTree = "<absolute>";
+			sourceTree = "<group>";
 		};
 		A7D395C1184FA34300A350D7 /* communitytype */ = {
 			isa = PBXGroup;
@@ -1801,8 +1800,7 @@
 				A7548FAE171440EC00B1F05A /* qFinderDMM.cpp */,
 			);
 			name = communitytype;
-			path = /Users/sarahwestcott/Desktop/mothur;
-			sourceTree = "<absolute>";
+			sourceTree = "<group>";
 		};
 		A7E9BA3812D3956100DA6239 /* commands */ = {
 			isa = PBXGroup;
@@ -2098,8 +2096,7 @@
 				A7E9B87A12D37EC400DA6239 /* venncommand.cpp */,
 			);
 			name = commands;
-			path = /Users/sarahwestcott/Desktop/mothur;
-			sourceTree = "<absolute>";
+			sourceTree = "<group>";
 		};
 		A7E9BA3F12D395F700DA6239 /* calculators */ = {
 			isa = PBXGroup;
@@ -2265,8 +2262,7 @@
 				A7E9B88012D37EC400DA6239 /* whittaker.h */,
 			);
 			name = calculators;
-			path = /Users/sarahwestcott/Desktop/mothur;
-			sourceTree = "<absolute>";
+			sourceTree = "<group>";
 		};
 		A7E9BA4212D3960D00DA6239 /* containers */ = {
 			isa = PBXGroup;
@@ -2359,8 +2355,7 @@
 				A7E9B86712D37EC400DA6239 /* treenode.h */,
 			);
 			name = containers;
-			path = /Users/sarahwestcott/Desktop/mothur;
-			sourceTree = "<absolute>";
+			sourceTree = "<group>";
 		};
 		A7E9BA4512D3965600DA6239 /* chimera */ = {
 			isa = PBXGroup;
@@ -2389,8 +2384,7 @@
 				A7E9B82F12D37EC400DA6239 /* slayer.h */,
 			);
 			name = chimera;
-			path = /Users/sarahwestcott/Desktop/mothur;
-			sourceTree = "<absolute>";
+			sourceTree = "<group>";
 		};
 		A7E9BA4B12D3966900DA6239 /* classifier */ = {
 			isa = PBXGroup;
@@ -2419,8 +2413,7 @@
 				A721AB73161C573B009860A1 /* taxonomynode.cpp */,
 			);
 			name = classifier;
-			path = /Users/sarahwestcott/Desktop/mothur;
-			sourceTree = "<absolute>";
+			sourceTree = "<group>";
 		};
 		A7E9BA4F12D398D700DA6239 /* clearcut */ = {
 			isa = PBXGroup;
@@ -2440,8 +2433,7 @@
 				A7E9B6FC12D37EC400DA6239 /* getopt_long.cpp */,
 			);
 			name = clearcut;
-			path = /Users/sarahwestcott/Desktop/mothur;
-			sourceTree = "<absolute>";
+			sourceTree = "<group>";
 		};
 		A7E9BA5312D39A5E00DA6239 /* read */ = {
 			isa = PBXGroup;
@@ -2482,8 +2474,7 @@
 				A73DDC3713C4BF64006AAE38 /* mothurmetastats.cpp */,
 			);
 			name = metastats;
-			path = /Users/sarahwestcott/Desktop/mothur;
-			sourceTree = "<absolute>";
+			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 


### PR DESCRIPTION
While trying to solve the RF issue, I came across this one.

A lot of files in the project still have absolute paths like this: `/Users/sarahwestcott/Desktop/mothur/source/commands/chimeravsearchcommand.cpp` so when I tried compiling it in a number of Macs I got the following error in Xcode 7.3.1:

```
clang: error: no such file or directory: '/Users/sarahwestcott/Desktop/mothur/source/commands/chimeravsearchcommand.cpp'
clang: error: no input files
```

I replaced the <absolute> references with <group> and it solved the problem (stack overflow link for a similar issue http://stackoverflow.com/questions/11614919/file-in-the-project-not-seen-by-xcode-after-git-pull)

Please take a look and see if this branch properly compiles in your setup.

### Detailed Log
```
CompileC /Users/azmfaridee/Library/Developer/Xcode/DerivedData/Mothur-fsqhrsrbhxrejwclcotiyjafkkpr/Build/Intermediates/Mothur.build/Debug/Mothur.build/Objects-normal/x86_64/chimeravsearchcommand.o /Users/sarahwestcott/Desktop/mothur/source/commands/chimeravsearchcommand.cpp normal x86_64 c++ com.apple.compilers.llvm.clang.1_0.compiler
cd /Users/azmfaridee/Documents/Development/mothur
export LANG=en_US.US-ASCII
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -x c++ -arch x86_64 -fmessage-length=0 -fdiagnostics-show-note-include-stack -fmacro-backtrace-limit=0 -Wno-trigraphs -fpascal-strings -O0 -Wno-missing-field-initializers -Wno-missing-prototypes -Wunreachable-code -Wno-non-virtual-dtor -Wno-overloaded-virtual -Wno-exit-time-destructors -Wno-missing-braces -Wparentheses -Wswitch -Wunused-function -Wno-unused-label -Wno-unused-parameter -Wunused-variable -Wunused-value -Wno-empty-body -Wno-uninitialized -Wno-unknown-pragmas -Wno-shadow -Wno-four-char-constants -Wno-conversion -Wno-constant-conversion -Wno-int-conversion -Wno-bool-conversion -Wno-enum-conversion -Wno-shorten-64-to-32 -Wnewline-eof -Wno-c++11-extensions -DVERSION=\"1.37.1\" -DRELEASE_DATE=\"04/11/2016\" -DMOTHUR_FILES=\"/Users/sarahwestcott/desktop/release\" -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk -fasm-blocks -fstrict-aliasing -Wdeprecated-declarations -Winvalid-offsetof -mmacosx-version-min=10.11 -g -fvisibility=hidden -fvisibility-inlines-hidden -Wno-sign-conversion -I/Users/azmfaridee/Library/Developer/Xcode/DerivedData/Mothur-fsqhrsrbhxrejwclcotiyjafkkpr/Build/Intermediates/Mothur.build/Debug/Mothur.build/mothur.hmap -I/usr/local/include -I/Users/azmfaridee/Library/Developer/Xcode/DerivedData/Mothur-fsqhrsrbhxrejwclcotiyjafkkpr/Build/Products/Debug/include -I/Users/azmfaridee/Library/Developer/Xcode/DerivedData/Mothur-fsqhrsrbhxrejwclcotiyjafkkpr/Build/Intermediates/Mothur.build/Debug/Mothur.build/DerivedSources/x86_64 -I/Users/azmfaridee/Library/Developer/Xcode/DerivedData/Mothur-fsqhrsrbhxrejwclcotiyjafkkpr/Build/Intermediates/Mothur.build/Debug/Mothur.build/DerivedSources -F/Users/azmfaridee/Library/Developer/Xcode/DerivedData/Mothur-fsqhrsrbhxrejwclcotiyjafkkpr/Build/Products/Debug -DBIT_VERSION -DUSE_BOOST -DUNIT_TEST -DUSE_READLINE -MMD -MT dependencies -MF /Users/azmfaridee/Library/Developer/Xcode/DerivedData/Mothur-fsqhrsrbhxrejwclcotiyjafkkpr/Build/Intermediates/Mothur.build/Debug/Mothur.build/Objects-normal/x86_64/chimeravsearchcommand.d --serialize-diagnostics /Users/azmfaridee/Library/Developer/Xcode/DerivedData/Mothur-fsqhrsrbhxrejwclcotiyjafkkpr/Build/Intermediates/Mothur.build/Debug/Mothur.build/Objects-normal/x86_64/chimeravsearchcommand.dia -c /Users/sarahwestcott/Desktop/mothur/source/commands/chimeravsearchcommand.cpp -o /Users/azmfaridee/Library/Developer/Xcode/DerivedData/Mothur-fsqhrsrbhxrejwclcotiyjafkkpr/Build/Intermediates/Mothur.build/Debug/Mothur.build/Objects-normal/x86_64/chimeravsearchcommand.o

clang: error: no such file or directory: '/Users/sarahwestcott/Desktop/mothur/source/commands/chimeravsearchcommand.cpp'
clang: error: no input files
```