### PR TITLE
Fix heatmap out of bounds memory access

### DIFF
--- a/source/heatmap.cpp
+++ b/source/heatmap.cpp
@@ -123,7 +123,7 @@ string HeatMap::getPic(vector<SharedRAbundVector*> lookup) {
 		if (sorted != "none") {  sortedLabels = sortSharedVectors(lookup);  }
 		
 		vector<vector<string> > scaleRelAbund;
-		vector<float> maxRelAbund(lookup[0]->size(), 0.0);		
+		vector<float> maxRelAbund(lookup.size(), 0.0);
 		float superMaxRelAbund = 0;
 		
 		for(int i = 0; i < lookup.size(); i++){


### PR DESCRIPTION
In HeatMap::getPic(), maxRelAbund is a vector of per-lookup values,
so it needs to be initialized to the size of lookup, not lookup[0].

Otherwise, when lookup[0]->size() < lookup.size(), we get a crash
due to out of bounds memory access when initializing maxRelAbund elements:

Program received signal SIGABRT, Aborted.
0x00007ffff6bb81d7 in raise () from /lib64/libc.so.6
(gdb) bt
#0  0x00007ffff6bb81d7 in raise () from /lib64/libc.so.6
#1  0x00007ffff6bb98c8 in abort () from /lib64/libc.so.6
#2  0x00007ffff6bf7f07 in __libc_message () from /lib64/libc.so.6
#3  0x00007ffff6bff503 in _int_free () from /lib64/libc.so.6
#4  0x0000000000445f5e in __gnu_cxx::new_allocator<float>::deallocate (this=0x7fffffffd6c0, __p=0x14d9f80) at /usr/lib/gcc/x86_64-pc-linux-gnu/4.8.5/include/g++-v4/ext/new_allocator.h:110
#5  0x0000000000443b4e in std::_Vector_base<float, std::allocator<float> >::_M_deallocate (this=0x7fffffffd6c0, __p=0x14d9f80, __n=43) at /usr/lib/gcc/x86_64-pc-linux-gnu/4.8.5/include/g++-v4/bits/stl_vector.h:174
#6  0x00000000004417cf in std::_Vector_base<float, std::allocator<float> >::~_Vector_base (this=0x7fffffffd6c0, __in_chrg=<optimized out>) at /usr/lib/gcc/x86_64-pc-linux-gnu/4.8.5/include/g++-v4/bits/stl_vector.h:160
#7  0x0000000000440159 in std::vector<float, std::allocator<float> >::~vector (this=0x7fffffffd6c0, __in_chrg=<optimized out>) at /usr/lib/gcc/x86_64-pc-linux-gnu/4.8.5/include/g++-v4/bits/stl_vector.h:416
#8  0x0000000000438e71 in HeatMap::getPic (this=0x14956a0, lookup=...) at source/heatmap.cpp:126
#9  0x00000000006c4ca9 in HeatMapCommand::execute (this=0x1493920) at source/commands/heatmapcommand.cpp:314
#10 0x0000000000578da9 in BatchEngine::getInput (this=0x148b4b0) at source/engine.cpp:258
#11 0x000000000040b8f2 in main (argc=<optimized out>, argv=<optimized out>) at source/mothur.cpp:237