### PR TITLE
make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@
 # BOOST_INCLUDE_DIR - location of boost include files
 # MOTHUR_FILES - default location for mothur to look for input files at runtime. Most often used for reference files.
 
+PREFIX := ${CURDIR} 
+
 64BIT_VERSION ?= yes
 OPTIMIZE ?= yes
 USEREADLINE ?= yes
@@ -89,7 +91,15 @@ mothur : $(OBJECTS) uchime
 uchime:
 	cd source/uchime_src && ./mk && mv uchime ../../ && cd ..
 
-install : mothur
+install : mothur uchime
+	if [[ "${CURDIR}" -ef "$(PREFIX)" ]]; then \
+		echo 'done' \
+	else \
+		mkdir -p $(PREFIX); \
+		for file in mothur uchime; do \
+			cp -f $$file $(PREFIX) ; \
+		done \
+	fi
 
 
 %.o : %.c %.h

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ uchime:
 	cd source/uchime_src && ./mk && mv uchime ../../ && cd ..
 
 install : mothur uchime
-	if [[ "${CURDIR}" -ef "$(PREFIX)" ]]; then \
+	if [ "${CURDIR}" = "$(PREFIX)" ]; then \
 		echo 'done' \
 	else \
 		mkdir -p $(PREFIX); \


### PR DESCRIPTION
Hi, I'm a contributor for the Homebrew package manager and we're in the process of updating and curating the build process of a lot of packages.

Mothur currently doesn't have a `make install` step, which makes it harder to ship and package in a standard way.

This pull request adds an `install` rule in the `Makefile`

`make install` would now install `mothur` and `uchime` in `/usr/local/bin` by default.
`make install PREFIX=/path/here` would allow the user to specify a custom location.

Best,
Hadrien