### PR TITLE
fix Get.communitytype - crash

### DIFF
--- a/source/commands/getmetacommunitycommand.cpp
+++ b/source/commands/getmetacommunitycommand.cpp
@@ -339,6 +339,16 @@ int GetMetaCommunityCommand::createProcesses(SharedRAbundVectors*& thislookup){
         rels.resize(1);
         matrix.resize(1);
         int minPartition = 0;
+
+        for (int i=1; i<=maxpartitions; i++) {
+          int processToAssign = 1;
+          dividedPartitions[(processToAssign-1)].push_back(i);
+          variables["[tag]"] = toString(i);
+          string relName = getOutputFileName("relabund", variables);
+          string mName = getOutputFileName("matrix", variables);
+          rels[(processToAssign-1)].push_back(relName);
+          matrix[(processToAssign-1)].push_back(mName);
+	}
         
         m->mothurOut("K\tNLE\t\tlogDet\tBIC\t\tAIC\t\tLaplace\n");
 		minPartition = processDriver(thislookup, dividedPartitions[0], outputFileName, rels[0], matrix[0], doneFlags, 0);

--- a/source/datastructures/sharedrabundvectors.cpp
+++ b/source/datastructures/sharedrabundvectors.cpp
@@ -551,6 +551,7 @@ RAbundVector SharedRAbundVectors::getRAbundVector(string group){
             //if this sharedrabund is not from a group the user wants then delete it.
             if ((*it)->getGroup() == group) {
                 for (int i = 0; i < (*it)->getNumBins(); i++) { rav.push_back((*it)->get(i)); }
+		return rav;
             }else { ++it; }
         }
         


### PR DESCRIPTION
This commit fix fix Get.communitytype - crash #467 

getmetacommunitycommand.cpp and sharedrabundvectors.cpp are changed

