### PR TITLE
Require that sequence to be merged be rarer than the idealized sequence

### DIFF
--- a/source/commands/preclustercommand.cpp
+++ b/source/commands/preclustercommand.cpp
@@ -12,7 +12,7 @@
 
 
 //**********************************************************************************************************************
-vector<string> PreClusterCommand::setParameters(){	
+vector<string> PreClusterCommand::setParameters(){
 	try {
 		CommandParameter pfasta("fasta", "InputTypes", "", "", "none", "none", "none","fasta-name",false,true,true); parameters.push_back(pfasta);
 		CommandParameter pname("name", "InputTypes", "", "", "NameCount", "none", "none","name",false,false,true); parameters.push_back(pname);
@@ -31,7 +31,7 @@ vector<string> PreClusterCommand::setParameters(){
 		CommandParameter pseed("seed", "Number", "", "0", "", "", "","",false,false); parameters.push_back(pseed);
         CommandParameter pinputdir("inputdir", "String", "", "", "", "", "","",false,false); parameters.push_back(pinputdir);
 		CommandParameter poutputdir("outputdir", "String", "", "", "", "", "","",false,false); parameters.push_back(poutputdir);
-		
+
 		vector<string> myArray;
 		for (int i = 0; i < parameters.size(); i++) {	myArray.push_back(parameters[i].name);		}
 		return myArray;
@@ -42,7 +42,7 @@ vector<string> PreClusterCommand::setParameters(){
 	}
 }
 //**********************************************************************************************************************
-string PreClusterCommand::getHelpString(){	
+string PreClusterCommand::getHelpString(){
 	try {
 		string helpString = "";
 		helpString += "The pre.cluster command groups sequences that are within a given number of base mismatches.\n";
@@ -73,13 +73,13 @@ string PreClusterCommand::getHelpString(){
 string PreClusterCommand::getOutputPattern(string type) {
     try {
         string pattern = "";
-        
-        if (type == "fasta") {  pattern = "[filename],precluster,[extension]"; } 
-        else if (type == "name") {  pattern = "[filename],precluster.names"; } 
+
+        if (type == "fasta") {  pattern = "[filename],precluster,[extension]"; }
+        else if (type == "name") {  pattern = "[filename],precluster.names"; }
         else if (type == "count") {  pattern = "[filename],precluster.count_table"; }
         else if (type == "map") {  pattern =  "[filename],precluster.map"; }
         else { m->mothurOut("[ERROR]: No definition for type " + type + " output pattern.\n"); m->setControl_pressed(true);  }
-        
+
         return pattern;
     }
     catch(exception& e) {
@@ -88,9 +88,9 @@ string PreClusterCommand::getOutputPattern(string type) {
     }
 }
 //**********************************************************************************************************************
-PreClusterCommand::PreClusterCommand(){	
+PreClusterCommand::PreClusterCommand(){
 	try {
-		abort = true; calledHelp = true; 
+		abort = true; calledHelp = true;
 		setParameters();
 		vector<string> tempOutNames;
 		outputTypes["fasta"] = tempOutNames;
@@ -107,65 +107,65 @@ PreClusterCommand::PreClusterCommand(){
 
 PreClusterCommand::PreClusterCommand(string option) {
 	try {
-		abort = false; calledHelp = false;   
-		
+		abort = false; calledHelp = false;
+
 		//allow user to run help
 		if(option == "help") { help(); abort = true; calledHelp = true; }
 		else if(option == "citation") { citation(); abort = true; calledHelp = true;}
-		
+
 		else {
 			vector<string> myArray = setParameters();
-			
+
 			OptionParser parser(option);
 			map<string, string> parameters = parser.getParameters();
-			
+
 			ValidParameters validParameter;
 			map<string, string>::iterator it;
-		
+
 			//check to make sure all parameters are valid for command
-			for (map<string, string>::iterator it2 = parameters.begin(); it2 != parameters.end(); it2++) { 
+			for (map<string, string>::iterator it2 = parameters.begin(); it2 != parameters.end(); it2++) {
 				if (validParameter.isValidParameter(it2->first, myArray, it2->second) != true) {  abort = true;  }
 			}
-			
+
 			//initialize outputTypes
 			vector<string> tempOutNames;
 			outputTypes["fasta"] = tempOutNames;
 			outputTypes["name"] = tempOutNames;
 			outputTypes["map"] = tempOutNames;
             outputTypes["count"] = tempOutNames;
-		
-			//if the user changes the input directory command factory will send this info to us in the output parameter 
-			string inputDir = validParameter.valid(parameters, "inputdir");		
+
+			//if the user changes the input directory command factory will send this info to us in the output parameter
+			string inputDir = validParameter.valid(parameters, "inputdir");
 			if (inputDir == "not found"){	inputDir = "";		}
 			else {
 				string path;
 				it = parameters.find("fasta");
 				//user has given a template file
-				if(it != parameters.end()){ 
+				if(it != parameters.end()){
 					path = util.hasPath(it->second);
 					//if the user has not given a path then, add inputdir. else leave path alone.
 					if (path == "") {	parameters["fasta"] = inputDir + it->second;		}
 				}
-				
+
 				it = parameters.find("name");
 				//user has given a template file
-				if(it != parameters.end()){ 
+				if(it != parameters.end()){
 					path = util.hasPath(it->second);
 					//if the user has not given a path then, add inputdir. else leave path alone.
 					if (path == "") {	parameters["name"] = inputDir + it->second;		}
 				}
-				
+
 				it = parameters.find("group");
 				//user has given a template file
-				if(it != parameters.end()){ 
+				if(it != parameters.end()){
 					path = util.hasPath(it->second);
 					//if the user has not given a path then, add inputdir. else leave path alone.
 					if (path == "") {	parameters["group"] = inputDir + it->second;		}
 				}
-                
+
                 it = parameters.find("count");
 				//user has given a template file
-				if(it != parameters.end()){ 
+				if(it != parameters.end()){
 					path = util.hasPath(it->second);
 					//if the user has not given a path then, add inputdir. else leave path alone.
 					if (path == "") {	parameters["count"] = inputDir + it->second;		}
@@ -174,79 +174,79 @@ PreClusterCommand::PreClusterCommand(string option) {
 
 			//check for required parameters
 			fastafile = validParameter.validFile(parameters, "fasta");
-			if (fastafile == "not found") { 				
-				fastafile = current->getFastaFile(); 
+			if (fastafile == "not found") {
+				fastafile = current->getFastaFile();
 				if (fastafile != "") { m->mothurOut("Using " + fastafile + " as input file for the fasta parameter."); m->mothurOutEndLine(); }
 				else { 	m->mothurOut("You have no current fastafile and the fasta parameter is required."); m->mothurOutEndLine(); abort = true; }
 			}
-			else if (fastafile == "not open") { abort = true; }	
+			else if (fastafile == "not open") { abort = true; }
 			else { current->setFastaFile(fastafile); }
-			
-			//if the user changes the output directory command factory will send this info to us in the output parameter 
-			outputDir = validParameter.valid(parameters, "outputdir");		if (outputDir == "not found"){	
-				outputDir = "";	
-				outputDir += util.hasPath(fastafile); //if user entered a file with a path then preserve it	
+
+			//if the user changes the output directory command factory will send this info to us in the output parameter
+			outputDir = validParameter.valid(parameters, "outputdir");		if (outputDir == "not found"){
+				outputDir = "";
+				outputDir += util.hasPath(fastafile); //if user entered a file with a path then preserve it
 			}
 
 			//check for optional parameter and set defaults
 			// ...at some point should added some additional type checking...
 			namefile = validParameter.validFile(parameters, "name");
 			if (namefile == "not found") { namefile =  "";  }
-			else if (namefile == "not open") { namefile = ""; abort = true; }	
+			else if (namefile == "not open") { namefile = ""; abort = true; }
 			else {  current->setNameFile(namefile); }
-			
+
 			groupfile = validParameter.validFile(parameters, "group");
 			if (groupfile == "not found") { groupfile =  "";  bygroup = false; }
-			else if (groupfile == "not open") { abort = true; groupfile =  ""; }	
+			else if (groupfile == "not open") { abort = true; groupfile =  ""; }
 			else {   current->setGroupFile(groupfile); bygroup = true;  }
-            
+
             countfile = validParameter.validFile(parameters, "count");
 			if (countfile == "not found") { countfile =  "";   }
-			else if (countfile == "not open") { abort = true; countfile =  ""; }	
-			else {   
-                current->setCountFile(countfile); 
+			else if (countfile == "not open") { abort = true; countfile =  ""; }
+			else {
+                current->setCountFile(countfile);
                 ct.readTable(countfile, true, false);
                 if (ct.hasGroupInfo()) { bygroup = true; }
                 else { bygroup = false;  }
             }
-            
+
             if ((namefile != "") && (countfile != "")) {
                 m->mothurOut("[ERROR]: you may only use one of the following: name or count."); m->mothurOutEndLine(); abort = true;
             }
-            
+
             if ((groupfile != "") && (countfile != "")) {
                 m->mothurOut("[ERROR]: you may only use one of the following: group or count."); m->mothurOutEndLine(); abort=true;
             }
 
-			
+
 			string temp	= validParameter.valid(parameters, "diffs");		if(temp == "not found"){	temp = "1"; }
-			util.mothurConvert(temp, diffs); 
-			
+			util.mothurConvert(temp, diffs);
+
 			temp = validParameter.valid(parameters, "processors");	if (temp == "not found"){	temp = current->getProcessors();	}
 			processors = current->setProcessors(temp);
-			
+
             temp = validParameter.valid(parameters, "topdown");		if(temp == "not found"){  temp = "T"; }
 			topdown = util.isTrue(temp);
-            
+
             temp = validParameter.valid(parameters, "match");		if (temp == "not found"){	temp = "1.0";			}
             util.mothurConvert(temp, match);
-            
+
             temp = validParameter.valid(parameters, "mismatch");		if (temp == "not found"){	temp = "-1.0";			}
             util.mothurConvert(temp, misMatch);
             if (misMatch > 0) { m->mothurOut("[ERROR]: mismatch must be negative.\n"); abort=true; }
-            
+
             temp = validParameter.valid(parameters, "gapopen");		if (temp == "not found"){	temp = "-2.0";			}
             util.mothurConvert(temp, gapOpen);
             if (gapOpen > 0) { m->mothurOut("[ERROR]: gapopen must be negative.\n"); abort=true; }
-            
+
             temp = validParameter.valid(parameters, "gapextend");	if (temp == "not found"){	temp = "-1.0";			}
             util.mothurConvert(temp, gapExtend);
             if (gapExtend > 0) { m->mothurOut("[ERROR]: gapextend must be negative.\n"); abort=true; }
 
             align = validParameter.valid(parameters, "align");		if (align == "not found"){	align = "needleman";	}
-            
+
             method = "unaligned";
-            
+
             if (countfile == "") {
                 if (namefile == "") {
                     vector<string> files; files.push_back(fastafile);
@@ -254,7 +254,7 @@ PreClusterCommand::PreClusterCommand(string option) {
                 }
             }
 		}
-				
+
 	}
 	catch(exception& e) {
 		m->errorOut(e, "PreClusterCommand", "PreClusterCommand");
@@ -279,7 +279,7 @@ inline bool comparePriorityTopDown(seqPNode* first, seqPNode* second) {
     //else if (first.numIdentical == second.numIdentical) {
     //if (first.seq.getName() > second.seq.getName()) { return true; }
     //}
-    
+
     return false;
 }
 /************************************************************/
@@ -306,7 +306,7 @@ struct preClusterData {
     map<string, vector<string> > outputTypes;
     vector<seqPNode*> alignSeqs; //maps the number of identical seqs to a sequence
     Alignment* alignment;
-    
+
     ~preClusterData() { if (alignment != NULL) { delete alignment; } }
     preClusterData(){}
     preClusterData(string f, string n, string g, string c, OutputWriter* nff,  OutputWriter* nnf, string nmf, vector<string> gr) {
@@ -335,7 +335,7 @@ struct preClusterData {
         gapExtend = gpEx;
         gapOpen = gpOp;
         length = 0;
-        
+
         if (method == "unaligned") {
             if(align == "gotoh")			{	alignment = new GotohOverlap(gapOpen, gapExtend, match, misMatch, 1000);	}
             else if(align == "needleman")	{	alignment = new NeedlemanOverlap(gapOpen, match, misMatch, 1000);			}
@@ -353,29 +353,29 @@ struct preClusterData {
 int calcMisMatches(string seq1, string seq2, preClusterData* params){
     try {
         int numBad = 0;
-        
+
         if (params->method == "unaligned") {
             //align to eachother
             Sequence seqI("seq1", seq1);
             Sequence seqJ("seq2", seq2);
-            
+
             //align seq2 to seq1 - less abundant to more abundant
             params->alignment->align(seqJ.getUnaligned(), seqI.getUnaligned());
             seq2 = params->alignment->getSeqAAln();
             seq1 = params->alignment->getSeqBAln();
-            
+
             //chop gap ends
             int startPos = 0;
             int endPos = seq2.length()-1;
             for (int i = 0; i < seq2.length(); i++) {  if (isalpha(seq2[i])) { startPos = i; break; } }
             for (int i = seq2.length()-1; i >= 0; i--) {  if (isalpha(seq2[i])) { endPos = i; break; } }
-            
+
             //count number of diffs
             for (int i = startPos; i <= endPos; i++) {
                 if (seq2[i] != seq1[i]) { numBad++; }
                 if (numBad > params->diffs) { return params->length;  } //to far to cluster
             }
-            
+
         }else {
             //count diffs
             for (int i = 0; i < seq1.length(); i++) {
@@ -396,36 +396,42 @@ int process(string group, string newMapFile, preClusterData* params){
     try {
         ofstream out;
         params->util.openOutputFile(newMapFile, out);
-        
+
         int count = 0;
         long long numSeqs = params->alignSeqs.size();
-        
+
+            map<int, string> mapFile;
+            map<int, int> originalCount;
+            map<int, int>::iterator itCount;
+            for (int i = 0; i < numSeqs; i++) { mapFile[i] = ""; originalCount[i] = params->alignSeqs[i]->numIdentical; }
+
+
         if (params->topdown) {
             //think about running through twice...
             for (int i = 0; i < numSeqs; i++) {
-                
+
                 if (params->alignSeqs[i]->active) {  //this sequence has not been merged yet
-                    
+
                     string chunk = params->alignSeqs[i]->seq.getName() + "\t" + toString(params->alignSeqs[i]->numIdentical) + "\t" + toString(0) + "\t" + params->alignSeqs[i]->seq.getAligned() + "\n";
-                    
+
                     //try to merge it with all smaller seqs
                     for (int j = i+1; j < numSeqs; j++) {
-                        
+
                         if (params->m->getControl_pressed()) { out.close(); return 0; }
-                        
-                        if (params->alignSeqs[j]->active) {  //this sequence has not been merged yet
+
+                        if (params->alignSeqs[j]->active & (originalCount[j] < originalCount[i])) {  //this sequence has not been merged yet
                             //are you within "diff" bases
                             int mismatch = params->length;
                             if (params->method == "unaligned") { mismatch = calcMisMatches(params->alignSeqs[i]->seq.getAligned(), params->alignSeqs[j]->seq.getAligned(), params); }
                             else { mismatch = calcMisMatches(params->alignSeqs[i]->filteredSeq, params->alignSeqs[j]->filteredSeq, params); }
-                            
+
                             if (mismatch <= params->diffs) {
                                 //merge
                                 params->alignSeqs[i]->names += ',' + params->alignSeqs[j]->names;
                                 params->alignSeqs[i]->numIdentical += params->alignSeqs[j]->numIdentical;
-                                
+
                                 chunk += params->alignSeqs[j]->seq.getName() + "\t" + toString(params->alignSeqs[j]->numIdentical) + "\t" + toString(mismatch) + "\t" + params->alignSeqs[j]->seq.getAligned() + "\n";
-                                
+
                                 params->alignSeqs[j]->active = 0;
                                 params->alignSeqs[j]->numIdentical = 0;
                                 params->alignSeqs[j]->diffs = mismatch;
@@ -433,40 +439,36 @@ int process(string group, string newMapFile, preClusterData* params){
                             }
                         }//end if j active
                     }//end for loop j
-                    
+
                     //remove from active list
                     params->alignSeqs[i]->active = 0;
-                    
+
                     out << "ideal_seq_" << (i+1) << '\t' << params->alignSeqs[i]->numIdentical << endl << chunk << endl;
-                    
+
                 }//end if active i
                 if(i % 100 == 0)	{ params->m->mothurOutJustToScreen(group + toString(i) + "\t" + toString(numSeqs - count) + "\t" + toString(count)+"\n"); 	}
             }
         }else {
-            map<int, string> mapFile;
-            map<int, int> originalCount;
-            map<int, int>::iterator itCount;
-            for (int i = 0; i < numSeqs; i++) { mapFile[i] = ""; originalCount[i] = params->alignSeqs[i]->numIdentical; }
-            
+
             //think about running through twice...
             for (int i = 0; i < numSeqs; i++) {
-                
+
                 //try to merge it into larger seqs
                 for (int j = i+1; j < numSeqs; j++) {
-                    
+
                     if (params->m->getControl_pressed()) { out.close(); return 0; }
-                    
+
                     if (originalCount[j] > originalCount[i]) {  //this sequence is more abundant than I am
                         //are you within "diff" bases
                         int mismatch = params->length;
                         if (params->method == "unaligned") { mismatch = calcMisMatches(params->alignSeqs[i]->seq.getAligned(), params->alignSeqs[j]->seq.getAligned(), params); }
                         else { mismatch = calcMisMatches(params->alignSeqs[i]->filteredSeq, params->alignSeqs[j]->filteredSeq, params); }
-                        
+
                         if (mismatch <= params->diffs) {
                             //merge
                             params->alignSeqs[j]->names += ',' + params->alignSeqs[i]->names;
                             params->alignSeqs[j]->numIdentical += params->alignSeqs[i]->numIdentical;
-                            
+
                             mapFile[j] = params->alignSeqs[i]->seq.getName() + "\t" + toString(params->alignSeqs[i]->numIdentical) + "\t" + toString(mismatch) + "\t" + params->alignSeqs[i]->seq.getAligned() + "\n" + mapFile[i];
                             params->alignSeqs[i]->numIdentical = 0;
                             originalCount.erase(i);
@@ -476,23 +478,23 @@ int process(string group, string newMapFile, preClusterData* params){
                         }
                     }//end abundance check
                 }//end for loop j
-                
+
                 if(i % 100 == 0)	{ params->m->mothurOutJustToScreen(toString(i) + "\t" + toString(numSeqs - count) + "\t" + toString(count)+"\n"); 	}
             }
-            
+
             for (int i = 0; i < numSeqs; i++) {
                 if (params->alignSeqs[i]->numIdentical != 0) {
                     out << "ideal_seq_" << (i+1) << '\t' << params->alignSeqs[i]->numIdentical << endl  << params->alignSeqs[i]->seq.getName() + "\t" + toString(params->alignSeqs[i]->numIdentical) + "\t" + toString(0) + "\t" + params->alignSeqs[i]->seq.getAligned() + "\n" << mapFile[i] << endl;
                 }
             }
-            
+
         }
         out.close();
-        
+
         if(numSeqs % 100 != 0)	{ params->m->mothurOut(group + toString(numSeqs) + "\t" + toString(numSeqs - count) + "\t" + toString(count) + "\n"); 	}
-        
+
         return count;
-        
+
     }
     catch(exception& e) {
         params->m->errorOut(e, "PreClusterCommand", "process");
@@ -504,17 +506,17 @@ void filterSeqs(vector<seqPNode*>& alignSeqs, int length, MothurOut* m){
     try {
         string filterString = "";
         Filters F;
-        
+
         F.setLength(length);
         F.initialize();
         F.setFilter(string(length, '1'));
-        
+
         for (int i = 0; i < alignSeqs.size(); i++) { F.getFreqs(alignSeqs[i]->seq); }
-        
+
         F.setNumSeqs(alignSeqs.size());
         F.doVerticalAllBases();
         filterString = F.getFilter();
-        
+
         //run filter
         for (int i = 0; i < alignSeqs.size(); i++) {
             if (m->getControl_pressed()) { break; }
@@ -534,23 +536,23 @@ vector<seqPNode*> readFASTA(CountTable ct, preClusterData* params, long long& nu
         map<string, string> nameMap;
         map<string, string>::iterator it;
         if (params->hasName) { params->util.readNames(params->namefile, nameMap); }
-        
+
         ifstream inFasta;
         params->util.openInputFile(params->fastafile, inFasta);
         set<int> lengths;
         vector<seqPNode*> alignSeqs;
-        
+
         while (!inFasta.eof()) {
-            
+
             if (params->m->getControl_pressed()) { inFasta.close(); break; }
-            
+
             Sequence seq(inFasta);  params->util.gobble(inFasta);
-            
+
             if (seq.getName() != "") {  //can get "" if commented line is at end of fasta file
-                
+
                 if (params->hasName) {
                     it = nameMap.find(seq.getName());
-                    
+
                     if (it == nameMap.end()) { params->m->mothurOut("[ERROR]: " + seq.getName() + " is not in your names file, please correct.\n"); exit(1); }
                     else{
                         string second = it->second;
@@ -569,18 +571,18 @@ vector<seqPNode*> readFASTA(CountTable ct, preClusterData* params, long long& nu
             }
         }
         inFasta.close();
-        
+
         params->length = *(lengths.begin());
-        
+
         if (lengths.size() > 1) { params->method = "unaligned"; }
         else if (lengths.size() == 1) {  params->method = "aligned"; filterSeqs(alignSeqs, params->length, params->m); }
-        
+
         //sort seqs by number of identical seqs
         if (params->topdown) { sort(alignSeqs.begin(), alignSeqs.end(), comparePriorityTopDown);  }
         else {  sort(alignSeqs.begin(), alignSeqs.end(), comparePriorityDownTop);  }
-        
+
         num = alignSeqs.size();
-        
+
         return alignSeqs;
     }
     catch(exception& e) {
@@ -593,12 +595,12 @@ void print(string newfasta, string newname, preClusterData* params){
     try {
         ofstream outFasta;
         ofstream outNames;
-        
+
         params->util.openOutputFile(newfasta, outFasta);
         params->util.openOutputFile(newname, outNames);
-        
+
         if (params->countfile != "")  { outNames << "Representative_Sequence\ttotal\n";  }
-        
+
         if (params->countfile != "") {
             for (int i = 0; i < params->alignSeqs.size(); i++) {
                 if (params->alignSeqs[i]->numIdentical != 0) {
@@ -616,7 +618,7 @@ void print(string newfasta, string newname, preClusterData* params){
         }
         outFasta.close();
         outNames.close();
-        
+
     }
     catch(exception& e) {
         params->m->errorOut(e, "PreClusterCommand", "print");
@@ -626,13 +628,13 @@ void print(string newfasta, string newname, preClusterData* params){
 /**************************************************************************************************/
 int PreClusterCommand::execute(){
 	try {
-		
+
 		if (abort) { if (calledHelp) { return 0; }  return 2;	}
-		
+
 		long start = time(NULL);
-        
+
 		string fileroot = outputDir + util.getRootName(util.getSimpleName(fastafile));
-        map<string, string> variables; 
+        map<string, string> variables;
         variables["[filename]"] = fileroot;
 		string newNamesFile = getOutputFileName("name",variables);
         string newCountFile = getOutputFileName("count",variables);
@@ -642,61 +644,61 @@ int PreClusterCommand::execute(){
 		outputNames.push_back(newFastaFile); outputTypes["fasta"].push_back(newFastaFile);
 		if (countfile == "") { outputNames.push_back(newNamesFile); outputTypes["name"].push_back(newNamesFile); }
 		else { outputNames.push_back(newCountFile); outputTypes["count"].push_back(newCountFile); }
-		
+
 		if (bygroup) {
 			//clear out old files
 			ofstream outFasta; util.openOutputFile(newFastaFile, outFasta); outFasta.close();
 			ofstream outNames; util.openOutputFile(newNamesFile, outNames);  outNames.close();
 			newMapFile = fileroot + "precluster.";
-			
+
 			createProcessesGroups(newFastaFile, newNamesFile, newMapFile);
-			
-			if (countfile != "") { 
+
+			if (countfile != "") {
                 mergeGroupCounts(newCountFile, newNamesFile, newFastaFile);
             }else {
                 //run unique.seqs for deconvolute results
                 string inputString = "fasta=" + newFastaFile;
                 if (namefile != "") { inputString += ", name=" + newNamesFile; }
-                
+
                 m->mothurOut("\n/******************************************/\n");
                 m->mothurOut("Running command: unique.seqs(" + inputString + ")\n");
                 current->setMothurCalling(true);
-                
+
                 Command* uniqueCommand = new DeconvoluteCommand(inputString);
                 uniqueCommand->execute();
-                
+
                 map<string, vector<string> > filenames = uniqueCommand->getOutputFiles();
-                
+
                 delete uniqueCommand;
                 current->setMothurCalling(false);
-                m->mothurOut("/******************************************/"); m->mothurOutEndLine(); 
-                
+                m->mothurOut("/******************************************/"); m->mothurOutEndLine();
+
                 util.renameFile(filenames["fasta"][0], newFastaFile);
-                util.renameFile(filenames["name"][0], newNamesFile); 
+                util.renameFile(filenames["name"][0], newNamesFile);
 			}
             if (m->getControl_pressed()) { for (int i = 0; i < outputNames.size(); i++) {	util.mothurRemove(outputNames[i]); 	}	 return 0; }
 			m->mothurOut("It took " + toString(time(NULL) - start) + " secs to run pre.cluster.\n");
-				
+
 		}else {
             if (processors != 1) { m->mothurOut("When using running without group information mothur can only use 1 processor, continuing."); m->mothurOutEndLine(); processors = 1; }
 
             preClusterData* params = new preClusterData(fastafile, namefile, groupfile, countfile, NULL, NULL, newMapFile, nullVector);
             params->setVariables(0,0, diffs, topdown, method, align, match, misMatch, gapOpen, gapExtend);
-            
+
             //reads fasta file and return number of seqs
             long long numSeqs = 0; params->alignSeqs = readFASTA(ct, params, numSeqs); //fills alignSeqs and makes all seqs active
             length = params->length;
-		
+
 			if (m->getControl_pressed()) { for (int i = 0; i < outputNames.size(); i++) {	util.mothurRemove(outputNames[i]); 	}  return 0; }
-	
+
 			if (numSeqs == 0) { m->mothurOut("Error reading fasta file...please correct.\n");  return 0;  }
 			if (diffs > length) { m->mothurOut("Error: diffs is set to " + toString(diffs) + " which is greater than your sequence length of " + toString(length) + ".\n");   return 0;  }
-			
+
 			int count = process("", newMapFile, params);
 			outputNames.push_back(newMapFile); outputTypes["map"].push_back(newMapFile);
-			
+
 			if (m->getControl_pressed()) { for (int i = 0; i < outputNames.size(); i++) {	util.mothurRemove(outputNames[i]); 	}  return 0; }
-			
+
 			m->mothurOut("Total number of sequences before precluster was " + toString(params->alignSeqs.size()) + ".\n");
 			m->mothurOut("pre.cluster removed " + toString(count) + " sequences.\n\n");
 			if (countfile != "") { newNamesFile = newCountFile; }
@@ -704,32 +706,32 @@ int PreClusterCommand::execute(){
             for (int i = 0; i < params->alignSeqs.size(); i++) {  delete params->alignSeqs[i]; } params->alignSeqs.clear();
 			m->mothurOut("It took " + toString(time(NULL) - start) + " secs to cluster " + toString(numSeqs) + " sequences.\n");
 		}
-				
+
 		if (m->getControl_pressed()) { for (int i = 0; i < outputNames.size(); i++) {	util.mothurRemove(outputNames[i]); 	}  return 0; }
-        
-		m->mothurOut("\nOutput File Names: \n"); 
-		for (int i = 0; i < outputNames.size(); i++) {	m->mothurOut(outputNames[i]); m->mothurOutEndLine();	}		
+
+		m->mothurOut("\nOutput File Names: \n");
+		for (int i = 0; i < outputNames.size(); i++) {	m->mothurOut(outputNames[i]); m->mothurOutEndLine();	}
 		m->mothurOutEndLine();
-		
+
 		//set fasta file as new current fastafile
 		string currentName = "";
 		itTypes = outputTypes.find("fasta");
 		if (itTypes != outputTypes.end()) {
 			if ((itTypes->second).size() != 0) { currentName = (itTypes->second)[0]; current->setFastaFile(currentName); }
 		}
-		
+
 		itTypes = outputTypes.find("name");
 		if (itTypes != outputTypes.end()) {
 			if ((itTypes->second).size() != 0) { currentName = (itTypes->second)[0]; current->setNameFile(currentName); }
 		}
-        
+
         itTypes = outputTypes.find("count");
 		if (itTypes != outputTypes.end()) {
 			if ((itTypes->second).size() != 0) { currentName = (itTypes->second)[0]; current->setCountFile(currentName); }
 		}
-		
+
 		return 0;
-		
+
 	}
 	catch(exception& e) {
 		m->errorOut(e, "PreClusterCommand", "execute");
@@ -744,14 +746,14 @@ vector<seqPNode*> loadSeqs(map<string, string>& thisName, vector<Sequence>& this
         bool error = false; num = 0;
         Utils util;
         vector<seqPNode*> alignSeqs;
-        
+
         for (int i = 0; i < thisSeqs.size(); i++) {
-            
+
             if (m->getControl_pressed()) { return alignSeqs; }
-            
+
             if (hasName) {
                 map<string, string>::iterator it = thisName.find(thisSeqs[i].getName());
-                
+
                 //should never be true since parser checks for this
                 if (it == thisName.end()) { m->mothurOut("[ERROR]: " + thisSeqs[i].getName() + " is not in your names file, please correct.\n"); error = true; }
                 else{
@@ -765,7 +767,7 @@ vector<seqPNode*> loadSeqs(map<string, string>& thisName, vector<Sequence>& this
                 int numRep = 1;
                 if (hasCount) {
                     map<string, int>::iterator it2 = thisCount.find(thisSeqs[i].getName());
-                    
+
                     //should never be true since parser checks for this
                     if (it2 == thisCount.end()) { m->mothurOut("[ERROR]: " + thisSeqs[i].getName() + " is not in your count file, please correct.\n"); error = true; }
                     else { numRep = it2->second;  }
@@ -775,23 +777,23 @@ vector<seqPNode*> loadSeqs(map<string, string>& thisName, vector<Sequence>& this
                 lengths.insert(thisSeqs[i].getAligned().length());
             }
         }
-        
+
         length = *(lengths.begin());
-        
+
         if (lengths.size() > 1) { method = "unaligned"; }
         else if (lengths.size() == 1) {  method = "aligned"; filterSeqs(alignSeqs, length, m); }
-        
+
         //sanity check
         if (error) { m->setControl_pressed(true); }
-        
+
         thisSeqs.clear();
-        
+
         //sort seqs by number of identical seqs
         if (topdown) { sort(alignSeqs.begin(), alignSeqs.end(), comparePriorityTopDown);  }
         else {  sort(alignSeqs.begin(), alignSeqs.end(), comparePriorityDownTop);  }
 
         num = alignSeqs.size();
-        
+
         return alignSeqs;
     }
     catch(exception& e) {
@@ -803,7 +805,7 @@ vector<seqPNode*> loadSeqs(map<string, string>& thisName, vector<Sequence>& this
 void printData(string group, preClusterData* params){
     try {
         if ((params->hasCount) && (group == ""))  { params->newNName->write("Representative_Sequence\ttotal\n");  }
-        
+
         if (params->hasCount) {
             if (group != "") {
                 for (int i = 0; i < params->alignSeqs.size(); i++) {
@@ -829,7 +831,7 @@ void printData(string group, preClusterData* params){
                 }
             }
         }
-       
+
     }
     catch(exception& e) {
         params->m->errorOut(e, "PreClusterCommand", "printData");
@@ -841,7 +843,7 @@ long long driverGroups(preClusterData* params){
 	try {
         vector<string> subsetGroups;
         for (int i = params->start; i < params->end; i++) {  subsetGroups.push_back(params->groups[i]);  }
-        
+
         //parse fasta and name file by group
         SequenceCountParser* cparser = NULL;
         SequenceParser* parser = NULL;
@@ -851,49 +853,49 @@ long long driverGroups(preClusterData* params){
             if (params->hasName) { parser = new SequenceParser(params->groupfile, params->fastafile, params->namefile, subsetGroups);	}
             else				{ parser = new SequenceParser(params->groupfile, params->fastafile, subsetGroups);                      }
         }
-        
+
 		long long numSeqs = 0;
-		
+
 		//precluster each group
 		for (int i = params->start; i < params->end; i++) {
 			if (params->m->getControl_pressed()) { if (params->hasCount) { delete cparser; }else { delete parser; } return numSeqs; }
-            
+
             params->m->mothurOut("\nProcessing group " + params->groups[i] + ":\n");
-            
+
 			time_t start = time(NULL);
 			map<string, string> thisNameMap;
             vector<Sequence> thisSeqs;
 			if (params->groupfile != "")        {  thisSeqs = parser->getSeqs(params->groups[i]);       }
             else if (params->hasCount)          { thisSeqs = cparser->getSeqs(params->groups[i]);       }
             if (params->hasName)                {  thisNameMap = parser->getNameMap(params->groups[i]); }
-            
+
             map<string, int> thisCount;
             if (params->hasCount) { thisCount = cparser->getCountTable(params->groups[i]);  }
-            
+
             long long num = 0;
 			params->alignSeqs = loadSeqs(thisNameMap, thisSeqs, thisCount, params->groups[i], num, params->hasName, params->hasCount, params->length, params->method, params->topdown);
             numSeqs += num;
-            
+
 			if (params->m->getControl_pressed()) {   return 0; }
-			
+
             if (params->method == "aligned") { if (params->diffs > params->length) { params->m->mothurOut("[ERROR]: diffs is greater than your sequence length.\n"); params->m->setControl_pressed(true); return 0;  } }
-			
+
             string extension = params->groups[i]+".map";
 			long long count = process(params->groups[i]+"\t", params->newMName+extension, params);
 			params->outputNames.push_back(params->newMName+extension); params->outputTypes["map"].push_back(params->newMName+extension);
-			
+
 			if (params->m->getControl_pressed()) {  return 0; }
-			
+
 			params->m->mothurOut("Total number of sequences before pre.cluster was " + toString(params->alignSeqs.size()) + ".\n");
 			params->m->mothurOut("pre.cluster removed " + toString(count) + " sequences.\n\n");
 			printData(params->groups[i], params);
             for (int i = 0; i < params->alignSeqs.size(); i++) {  delete params->alignSeqs[i]; } params->alignSeqs.clear();
-			
+
 			params->m->mothurOut("It took " + toString(time(NULL) - start) + " secs to cluster " + toString(num) + " sequences.\n");
 		}
-		
+
         if (params->hasCount) { delete cparser; }else { delete parser; }
-        
+
 		return numSeqs;
 	}
 	catch(exception& e) {
@@ -907,7 +909,7 @@ int PreClusterCommand::mergeGroupCounts(string newcount, string newname, string 
 	try {
 		ifstream inNames;
         util.openInputFile(newname, inNames);
-        
+
         string group, first, second;
         set<string> uniqueNames;
         while (!inNames.eof()) {
@@ -915,12 +917,12 @@ int PreClusterCommand::mergeGroupCounts(string newcount, string newname, string 
             inNames >> group; util.gobble(inNames);
             inNames >> first; util.gobble(inNames);
             inNames >> second; util.gobble(inNames);
-            
+
             vector<string> names;
             util.splitAtComma(second, names);
-            
+
             uniqueNames.insert(first);
-            
+
             int total = ct.getGroupCount(first, group);
             for (int i = 1; i < names.size(); i++) {
                 total += ct.getGroupCount(names[i], group);
@@ -929,31 +931,31 @@ int PreClusterCommand::mergeGroupCounts(string newcount, string newname, string 
             ct.setAbund(first, group, total);
         }
         inNames.close();
-        
+
         vector<string> namesOfSeqs = ct.getNamesOfSeqs();
         for (int i = 0; i < namesOfSeqs.size(); i++) {
             if (ct.getNumSeqs(namesOfSeqs[i]) == 0) {
                 ct.remove(namesOfSeqs[i]);
             }
         }
-        
-        ct.printTable(newcount); 
+
+        ct.printTable(newcount);
         util.mothurRemove(newname);
-        
+
         if (bygroup) { //if by group, must remove the duplicate seqs that are named the same
             ifstream in;
             util.openInputFile(newfasta, in);
-            
+
             ofstream out;
             util.openOutputFile(newfasta+"temp", out);
-            
+
             int count = 0;
             set<string> already;
             while(!in.eof()) {
                 if (m->getControl_pressed()) { break; }
-                
+
                 Sequence seq(in); util.gobble(in);
-                
+
                 if (seq.getName() != "") {
                     count++;
                     if (already.count(seq.getName()) == 0) {
@@ -968,7 +970,7 @@ int PreClusterCommand::mergeGroupCounts(string newcount, string newname, string 
             util.renameFile(newfasta+"temp", newfasta);
         }
 		        return 0;
-		
+
 	}
 	catch(exception& e) {
 		m->errorOut(e, "PreClusterCommand", "mergeGroupCounts");
@@ -983,10 +985,10 @@ void PreClusterCommand::createProcessesGroups(string newFName, string newNName, 
         vector<string> groups;
         if (countfile != "") { CountTable ct; ct.testGroups(countfile, groups); }
         else { GroupMap gp; gp.readMap(groupfile); groups = gp.getNamesOfGroups(); }
-        
+
         //sanity check
         if (groups.size() < processors) { processors = groups.size(); m->mothurOut("Reducing processors to " + toString(groups.size()) + ".\n"); }
-        
+
         //divide the groups between the processors
         vector<linePair> lines;
         int remainingPairs = groups.size();
@@ -998,46 +1000,46 @@ void PreClusterCommand::createProcessesGroups(string newFName, string newNName, 
             startIndex = startIndex + numPairs;
             remainingPairs = remainingPairs - numPairs;
         }
-        
+
         //create array of worker threads
         vector<thread*> workerThreads;
         vector<preClusterData*> data;
-        
+
         auto synchronizedFastaFile = std::make_shared<SynchronizedOutputFile>(newFName);
         auto synchronizedNameFile = std::make_shared<SynchronizedOutputFile>(newNName);
-        
+
         //Lauch worker threads
         for (int i = 0; i < processors-1; i++) {
             OutputWriter* threadFastaWriter = new OutputWriter(synchronizedFastaFile);
             OutputWriter* threadNameWriter = new OutputWriter(synchronizedNameFile);
-            
+
             preClusterData* dataBundle = new preClusterData(fastafile, namefile, groupfile, countfile, threadFastaWriter, threadNameWriter, newMFile, groups);
             dataBundle->setVariables(lines[i+1].start, lines[i+1].end, diffs, topdown, method, align, match, misMatch, gapOpen, gapExtend);
             data.push_back(dataBundle);
-            
+
             workerThreads.push_back(new thread(driverGroups, dataBundle));
         }
-        
+
         OutputWriter* threadFastaWriter = new OutputWriter(synchronizedFastaFile);
         OutputWriter* threadNameWriter = new OutputWriter(synchronizedNameFile);
-        
+
         preClusterData* dataBundle = new preClusterData(fastafile, namefile, groupfile, countfile, threadFastaWriter, threadNameWriter, newMFile, groups);
         dataBundle->setVariables(lines[0].start, lines[0].end, diffs, topdown, method, align, match, misMatch, gapOpen, gapExtend);
 
         driverGroups(dataBundle);
-        
+
         outputNames.insert(outputNames.end(), dataBundle->outputNames.begin(), dataBundle->outputNames.end());
         outputTypes.insert(dataBundle->outputTypes.begin(), dataBundle->outputTypes.end());
-        
+
         for (int i = 0; i < processors-1; i++) {
             workerThreads[i]->join();
-            
+
             delete data[i]->newFName;
             delete data[i]->newNName;
-            
+
             outputNames.insert(outputNames.end(), data[i]->outputNames.begin(), data[i]->outputNames.end());
             outputTypes.insert(data[i]->outputTypes.begin(), data[i]->outputTypes.end());
-            
+
             delete data[i];
             delete workerThreads[i];
         }
@@ -1052,5 +1054,3 @@ void PreClusterCommand::createProcessesGroups(string newFName, string newNName, 
     }
 }
 /**************************************************************************************************/
-
-


### PR DESCRIPTION
Not sure where this crept in, but for a sequence to be merged with an ideal sequence, it should be rarer than the ideal sequence. For example, if an ideal sequence occurs 5 times, it should not be merged with a one-off that also occurs 5 times. Thinking about this mechanistically, it would be pretty random which of the two showed up first in the queue and was named the ideal sequence. Also, sequencing/PCR errors should be rarer than the ideal version of that sequence.