### PR TITLE
Additional precluster features

### DIFF
--- a/source/commands/preclustercommand.cpp
+++ b/source/commands/preclustercommand.cpp
@@ -867,14 +867,13 @@ int process(string group, string newMapFile, preClusterData* params){
 			}
 
 			for(int i=0;i<numSeqs;i++){
+				params->alignSeqs[i]->numIdentical = round(weights[i]);
+
 				if(weights[i] <= 0){
 					params->alignSeqs[i]->numIdentical = 0;
 					params->alignSeqs[i]->active = 0;
-				} else {
-					params->alignSeqs[i]->numIdentical = round(weights[i]);
+					count++;
 				}
-
-				if(params->alignSeqs[i]->numIdentical == 0) { count++; }
 			}
 
 		} else {
@@ -925,7 +924,9 @@ void filterSeqs(vector<seqPNode*>& alignSeqs, int length, MothurOut* m){
         exit(1);
     }
 }
+
 /**************************************************************************************************/
+
 vector<seqPNode*> readFASTA(CountTable ct, preClusterData* params, long long& num){
     try {
         map<string, string> nameMap;
@@ -983,7 +984,9 @@ vector<seqPNode*> readFASTA(CountTable ct, preClusterData* params, long long& nu
         exit(1);
     }
 }
+
 /**************************************************************************************************/
+
 void print(string newfasta, string newname, preClusterData* params){
     try {
         ofstream outFasta;
@@ -1018,6 +1021,7 @@ void print(string newfasta, string newname, preClusterData* params){
         exit(1);
     }
 }
+
 /**************************************************************************************************/
 int PreClusterCommand::execute(){
 	try {
@@ -1027,16 +1031,22 @@ int PreClusterCommand::execute(){
 		long start = time(NULL);
 
 		string fileroot = outputDir + util.getRootName(util.getSimpleName(fastafile));
-        map<string, string> variables;
-        variables["[filename]"] = fileroot;
+		map<string, string> variables;
+		variables["[filename]"] = fileroot;
+
 		string newNamesFile = getOutputFileName("name",variables);
-        string newCountFile = getOutputFileName("count",variables);
+		string newCountFile = getOutputFileName("count",variables);
 		string newMapFile = getOutputFileName("map",variables); //add group name if by group
-        variables["[extension]"] = util.getExtension(fastafile);
+
+		variables["[extension]"] = util.getExtension(fastafile);
 		string newFastaFile = getOutputFileName("fasta", variables);
 		outputNames.push_back(newFastaFile); outputTypes["fasta"].push_back(newFastaFile);
-		if (countfile == "") { outputNames.push_back(newNamesFile); outputTypes["name"].push_back(newNamesFile); }
-		else { outputNames.push_back(newCountFile); outputTypes["count"].push_back(newCountFile); }
+
+		if (countfile == "") {
+			outputNames.push_back(newNamesFile); outputTypes["name"].push_back(newNamesFile);
+		}	else {
+			outputNames.push_back(newCountFile); outputTypes["count"].push_back(newCountFile);
+		}
 
 		if (bygroup) {
 			//clear out old files
@@ -1047,29 +1057,32 @@ int PreClusterCommand::execute(){
 			createProcessesGroups(newFastaFile, newNamesFile, newMapFile);
 
 			if (countfile != "") {
-                mergeGroupCounts(newCountFile, newNamesFile, newFastaFile);
-            }else {
-                //run unique.seqs for deconvolute results
-                string inputString = "fasta=" + newFastaFile;
-                if (namefile != "") { inputString += ", name=" + newNamesFile; }
+					cout << "here\n";
+    			// mergeGroupCounts(newCountFile, newNamesFile, newFastaFile);
+      } else {
+        //run unique.seqs for deconvolute results
+        string inputString = "fasta=" + newFastaFile;
+        if (namefile != "") { inputString += ", name=" + newNamesFile; }
 
-                m->mothurOut("\n/******************************************/\n");
-                m->mothurOut("Running command: unique.seqs(" + inputString + ")\n");
-                current->setMothurCalling(true);
+        m->mothurOut("\n/******************************************/\n");
+        m->mothurOut("Running command: unique.seqs(" + inputString + ")\n");
+        current->setMothurCalling(true);
 
-                Command* uniqueCommand = new DeconvoluteCommand(inputString);
-                uniqueCommand->execute();
+        Command* uniqueCommand = new DeconvoluteCommand(inputString);
+        uniqueCommand->execute();
 
-                map<string, vector<string> > filenames = uniqueCommand->getOutputFiles();
+        map<string, vector<string> > filenames = uniqueCommand->getOutputFiles();
 
-                delete uniqueCommand;
-                current->setMothurCalling(false);
-                m->mothurOut("/******************************************/"); m->mothurOutEndLine();
+        delete uniqueCommand;
+        current->setMothurCalling(false);
+        m->mothurOut("/******************************************/"); m->mothurOutEndLine();
 
-                util.renameFile(filenames["fasta"][0], newFastaFile);
-                util.renameFile(filenames["name"][0], newNamesFile);
+        util.renameFile(filenames["fasta"][0], newFastaFile);
+        util.renameFile(filenames["name"][0], newNamesFile);
 			}
-            if (m->getControl_pressed()) { for (int i = 0; i < outputNames.size(); i++) {	util.mothurRemove(outputNames[i]); 	}	 return 0; }
+
+      if (m->getControl_pressed()) { for (int i = 0; i < outputNames.size(); i++) {	util.mothurRemove(outputNames[i]); 	}	 return 0; }
+
 			m->mothurOut("It took " + toString(time(NULL) - start) + " secs to run pre.cluster.\n");
 
 		}else {
@@ -1133,7 +1146,9 @@ int PreClusterCommand::execute(){
 		exit(1);
 	}
 }
+
 /**************************************************************************************************/
+
 vector<seqPNode*> loadSeqs(map<string, string>& thisName, vector<Sequence>& thisSeqs, map<string, int>& thisCount, string group, long long& num, bool hasName, bool hasCount, int& length, string& align_method){
     MothurOut* m = MothurOut::getInstance();
     try {
@@ -1195,21 +1210,32 @@ vector<seqPNode*> loadSeqs(map<string, string>& thisName, vector<Sequence>& this
         exit(1);
     }
 }
+
 /**************************************************************************************************/
+
 void printData(string group, preClusterData* params){
     try {
-        if ((params->hasCount) && (group == ""))  { params->newNName->write("Representative_Sequence\ttotal\n");  }
+        if ((params->hasCount) && (group == ""))  {
+					params->newNName->write("Representative_Sequence\ttotal\n");
+				}
 
         if (params->hasCount) {
             if (group != "") {
+
                 for (int i = 0; i < params->alignSeqs.size(); i++) {
                     if (params->alignSeqs[i]->numIdentical != 0) {
                         params->alignSeqs[i]->seq.printSequence(params->newFName);
-                        params->newNName->write(group + '\t' + params->alignSeqs[i]->seq.getName() + '\t' + params->alignSeqs[i]->names + '\n');
+
+												if(params->pc_method == "deblur"){
+                        	params->newNName->write(group + '\t' + params->alignSeqs[i]->seq.getName() + '\t' + toString(params->alignSeqs[i]->numIdentical) + '\n');
+												} else {
+                        	params->newNName->write(group + '\t' + params->alignSeqs[i]->seq.getName() + '\t' + params->alignSeqs[i]->names + '\n');
+												}
                     }
                 }
             }
             else {
+
                 for (int i = 0; i < params->alignSeqs.size(); i++) {
                     if (params->alignSeqs[i]->numIdentical != 0) {
                         params->alignSeqs[i]->seq.printSequence(params->newFName);
@@ -1233,20 +1259,21 @@ void printData(string group, preClusterData* params){
     }
 }
 /**************************************************************************************************/
+
 long long driverGroups(preClusterData* params){
 	try {
-        vector<string> subsetGroups;
-        for (int i = params->start; i < params->end; i++) {  subsetGroups.push_back(params->groups[i]);  }
+    vector<string> subsetGroups;
+    for (int i = params->start; i < params->end; i++) {  subsetGroups.push_back(params->groups[i]);  }
 
-        //parse fasta and name file by group
-        SequenceCountParser* cparser = NULL;
-        SequenceParser* parser = NULL;
-        if (params->hasCount) {
-            cparser = new SequenceCountParser(params->countfile, params->fastafile, subsetGroups);
-        }else {
-            if (params->hasName) { parser = new SequenceParser(params->groupfile, params->fastafile, params->namefile, subsetGroups);	}
-            else				{ parser = new SequenceParser(params->groupfile, params->fastafile, subsetGroups);                      }
-        }
+    //parse fasta and name file by group
+    SequenceCountParser* cparser = NULL;
+    SequenceParser* parser = NULL;
+    if (params->hasCount) {
+        cparser = new SequenceCountParser(params->countfile, params->fastafile, subsetGroups);
+    }else {
+        if (params->hasName) { parser = new SequenceParser(params->groupfile, params->fastafile, params->namefile, subsetGroups);	}
+        else				{ parser = new SequenceParser(params->groupfile, params->fastafile, subsetGroups);                      }
+    }
 
 		long long numSeqs = 0;
 
@@ -1254,29 +1281,41 @@ long long driverGroups(preClusterData* params){
 		for (int i = params->start; i < params->end; i++) {
 			if (params->m->getControl_pressed()) { if (params->hasCount) { delete cparser; }else { delete parser; } return numSeqs; }
 
-            params->m->mothurOut("\nProcessing group " + params->groups[i] + ":\n");
+      params->m->mothurOut("\nProcessing group " + params->groups[i] + ":\n");
 
 			time_t start = time(NULL);
 			map<string, string> thisNameMap;
-            vector<Sequence> thisSeqs;
+      vector<Sequence> thisSeqs;
+
 			if (params->groupfile != "")        {  thisSeqs = parser->getSeqs(params->groups[i]);       }
-            else if (params->hasCount)          { thisSeqs = cparser->getSeqs(params->groups[i]);       }
-            if (params->hasName)                {  thisNameMap = parser->getNameMap(params->groups[i]); }
+      else if (params->hasCount)          { thisSeqs = cparser->getSeqs(params->groups[i]);       }
 
-            map<string, int> thisCount;
-            if (params->hasCount) { thisCount = cparser->getCountTable(params->groups[i]);  }
+      if (params->hasName)                {  thisNameMap = parser->getNameMap(params->groups[i]); }
 
-            long long num = 0;
+      map<string, int> thisCount;
+      if (params->hasCount) { thisCount = cparser->getCountTable(params->groups[i]);  }
+
+      long long num = 0;
 			params->alignSeqs = loadSeqs(thisNameMap, thisSeqs, thisCount, params->groups[i], num, params->hasName, params->hasCount, params->length, params->align_method);
-            numSeqs += num;
+      numSeqs += num;
 
 			if (params->m->getControl_pressed()) {   return 0; }
 
-            if (params->align_method == "aligned") { if (params->diffs > params->length) { params->m->mothurOut("[ERROR]: diffs is greater than your sequence length.\n"); params->m->setControl_pressed(true); return 0;  } }
+      if (params->align_method == "aligned") {
+				if (params->diffs > params->length) {
+					params->m->mothurOut("[ERROR]: diffs is greater than your sequence length.\n");
+					params->m->setControl_pressed(true);
+					return 0;
+				}
+			}
 
-            string extension = params->groups[i]+".map";
+      string extension = params->groups[i]+".map";
 			long long count = process(params->groups[i]+"\t", params->newMName+extension, params);
-			params->outputNames.push_back(params->newMName+extension); params->outputTypes["map"].push_back(params->newMName+extension);
+
+			if(params->pc_method != "deblur"){
+				params->outputNames.push_back(params->newMName+extension);
+				params->outputTypes["map"].push_back(params->newMName+extension);
+			}
 
 			if (params->m->getControl_pressed()) {  return 0; }
 
@@ -1288,7 +1327,7 @@ long long driverGroups(preClusterData* params){
 			params->m->mothurOut("It took " + toString(time(NULL) - start) + " secs to cluster " + toString(num) + " sequences.\n");
 		}
 
-        if (params->hasCount) { delete cparser; }else { delete parser; }
+    if (params->hasCount) { delete cparser; }else { delete parser; }
 
 		return numSeqs;
 	}
@@ -1297,74 +1336,84 @@ long long driverGroups(preClusterData* params){
 		exit(1);
 	}
 }
+
 /**************************************************************************************************/
 
 int PreClusterCommand::mergeGroupCounts(string newcount, string newname, string newfasta){
 	try {
 		ifstream inNames;
-        util.openInputFile(newname, inNames);
+    util.openInputFile(newname, inNames);
 
-        string group, first, second;
-        set<string> uniqueNames;
-        while (!inNames.eof()) {
-            if (m->getControl_pressed()) { break; }
-            inNames >> group; util.gobble(inNames);
-            inNames >> first; util.gobble(inNames);
-            inNames >> second; util.gobble(inNames);
+    string group, first, second;
+    set<string> uniqueNames;
 
-            vector<string> names;
-            util.splitAtComma(second, names);
+    while (!inNames.eof()) {
 
-            uniqueNames.insert(first);
+      if (m->getControl_pressed()) { break; }
 
-            int total = ct.getGroupCount(first, group);
-            for (int i = 1; i < names.size(); i++) {
-                total += ct.getGroupCount(names[i], group);
-                ct.setAbund(names[i], group, 0);
-            }
-            ct.setAbund(first, group, total);
+      inNames >> group; util.gobble(inNames);
+      inNames >> first; util.gobble(inNames);
+      inNames >> second; util.gobble(inNames);
+
+      vector<string> names;
+      util.splitAtComma(second, names);
+
+      uniqueNames.insert(first);
+
+	    int total = ct.getGroupCount(first, group);
+
+			// if(method != "deblur"){
+	    //   for (int i = 1; i < names.size(); i++) {
+	    //       total += ct.getGroupCount(names[i], group);
+	    //       ct.setAbund(names[i], group, 0);
+	    //   }
+			// } else {
+				int count = stoi(second);
+        total += count;
+			// }
+      ct.setAbund(first, group, total);
+    }
+    inNames.close();
+
+    vector<string> namesOfSeqs = ct.getNamesOfSeqs();
+    for (int i = 0; i < namesOfSeqs.size(); i++) {
+        if (ct.getNumSeqs(namesOfSeqs[i]) == 0) {
+            ct.remove(namesOfSeqs[i]);
         }
-        inNames.close();
+    }
 
-        vector<string> namesOfSeqs = ct.getNamesOfSeqs();
-        for (int i = 0; i < namesOfSeqs.size(); i++) {
-            if (ct.getNumSeqs(namesOfSeqs[i]) == 0) {
-                ct.remove(namesOfSeqs[i]);
-            }
+    ct.printTable(newcount);
+    util.mothurRemove(newname);
+
+    if (bygroup) { //if by group, must remove the duplicate seqs that are named the same
+      ifstream in;
+      util.openInputFile(newfasta, in);
+
+      ofstream out;
+      util.openOutputFile(newfasta+"temp", out);
+
+      int count = 0;
+      set<string> already;
+      while(!in.eof()) {
+        if (m->getControl_pressed()) { break; }
+
+        Sequence seq(in); util.gobble(in);
+
+        if (seq.getName() != "") {
+          count++;
+          if (already.count(seq.getName()) == 0) {
+            seq.printSequence(out);
+            already.insert(seq.getName());
+          }
         }
+      }
+      in.close();
+      out.close();
+      util.mothurRemove(newfasta);
+      util.renameFile(newfasta+"temp", newfasta);
+    }
 
-        ct.printTable(newcount);
-        util.mothurRemove(newname);
-
-        if (bygroup) { //if by group, must remove the duplicate seqs that are named the same
-            ifstream in;
-            util.openInputFile(newfasta, in);
-
-            ofstream out;
-            util.openOutputFile(newfasta+"temp", out);
-
-            int count = 0;
-            set<string> already;
-            while(!in.eof()) {
-                if (m->getControl_pressed()) { break; }
-
-                Sequence seq(in); util.gobble(in);
-
-                if (seq.getName() != "") {
-                    count++;
-                    if (already.count(seq.getName()) == 0) {
-                        seq.printSequence(out);
-                        already.insert(seq.getName());
-                    }
-                }
-            }
-            in.close();
-            out.close();
-            util.mothurRemove(newfasta);
-            util.renameFile(newfasta+"temp", newfasta);
-        }
-		        return 0;
-
+		return 0;
 	}
 	catch(exception& e) {
 		m->errorOut(e, "PreClusterCommand", "mergeGroupCounts");
@@ -1373,78 +1422,80 @@ int PreClusterCommand::mergeGroupCounts(string newcount, string newname, string 
 }
 
 /**************************************************************************************************/
+
 void PreClusterCommand::createProcessesGroups(string newFName, string newNName, string newMFile) {
-    try {
-        //parse fasta and name file by group
-        vector<string> groups;
-        if (countfile != "") { CountTable ct; ct.testGroups(countfile, groups); }
-        else { GroupMap gp; gp.readMap(groupfile); groups = gp.getNamesOfGroups(); }
+  try {
+    //parse fasta and name file by group
+    vector<string> groups;
+    if (countfile != "") { CountTable ct; ct.testGroups(countfile, groups); }
+    else { GroupMap gp; gp.readMap(groupfile); groups = gp.getNamesOfGroups(); }
 
-        //sanity check
-        if (groups.size() < processors) { processors = groups.size(); m->mothurOut("Reducing processors to " + toString(groups.size()) + ".\n"); }
+    //sanity check
+    if (groups.size() < processors) { processors = groups.size(); m->mothurOut("Reducing processors to " + toString(groups.size()) + ".\n"); }
 
-        //divide the groups between the processors
-        vector<linePair> lines;
-        int remainingPairs = groups.size();
-        int startIndex = 0;
-        for (int remainingProcessors = processors; remainingProcessors > 0; remainingProcessors--) {
-            int numPairs = remainingPairs; //case for last processor
-            if (remainingProcessors != 1) { numPairs = ceil(remainingPairs / remainingProcessors); }
-            lines.push_back(linePair(startIndex, (startIndex+numPairs))); //startIndex, endIndex
-            startIndex = startIndex + numPairs;
-            remainingPairs = remainingPairs - numPairs;
-        }
-
-        //create array of worker threads
-        vector<thread*> workerThreads;
-        vector<preClusterData*> data;
-
-        auto synchronizedFastaFile = std::make_shared<SynchronizedOutputFile>(newFName);
-        auto synchronizedNameFile = std::make_shared<SynchronizedOutputFile>(newNName);
-
-        //Lauch worker threads
-        for (int i = 0; i < processors-1; i++) {
-            OutputWriter* threadFastaWriter = new OutputWriter(synchronizedFastaFile);
-            OutputWriter* threadNameWriter = new OutputWriter(synchronizedNameFile);
-
-            preClusterData* dataBundle = new preClusterData(fastafile, namefile, groupfile, countfile, pc_method, align_method, threadFastaWriter, threadNameWriter, newMFile, groups);
-            dataBundle->setVariables(lines[i+1].start, lines[i+1].end, diffs, pc_method, align_method, align, match, misMatch, gapOpen, gapExtend, alpha, delta, error_rate, indel_prob, max_indels, error_dist);
-            data.push_back(dataBundle);
-
-            workerThreads.push_back(new thread(driverGroups, dataBundle));
-        }
-
-        OutputWriter* threadFastaWriter = new OutputWriter(synchronizedFastaFile);
-        OutputWriter* threadNameWriter = new OutputWriter(synchronizedNameFile);
-
-        preClusterData* dataBundle = new preClusterData(fastafile, namefile, groupfile, countfile, pc_method, align_method, threadFastaWriter, threadNameWriter, newMFile, groups);
-        dataBundle->setVariables(lines[0].start, lines[0].end, diffs, pc_method, align_method, align, match, misMatch, gapOpen, gapExtend, alpha, delta, error_rate, indel_prob, max_indels, error_dist);
-
-        driverGroups(dataBundle);
-
-        outputNames.insert(outputNames.end(), dataBundle->outputNames.begin(), dataBundle->outputNames.end());
-        outputTypes.insert(dataBundle->outputTypes.begin(), dataBundle->outputTypes.end());
-
-        for (int i = 0; i < processors-1; i++) {
-            workerThreads[i]->join();
-
-            delete data[i]->newFName;
-            delete data[i]->newNName;
-
-            outputNames.insert(outputNames.end(), data[i]->outputNames.begin(), data[i]->outputNames.end());
-            outputTypes.insert(data[i]->outputTypes.begin(), data[i]->outputTypes.end());
-
-            delete data[i];
-            delete workerThreads[i];
-        }
-        delete threadFastaWriter;
-        delete threadNameWriter;
-        delete dataBundle;
-
+    //divide the groups between the processors
+    vector<linePair> lines;
+    int remainingPairs = groups.size();
+    int startIndex = 0;
+    for (int remainingProcessors = processors; remainingProcessors > 0; remainingProcessors--) {
+      int numPairs = remainingPairs; //case for last processor
+      if (remainingProcessors != 1) { numPairs = ceil(remainingPairs / remainingProcessors); }
+      lines.push_back(linePair(startIndex, (startIndex+numPairs))); //startIndex, endIndex
+      startIndex = startIndex + numPairs;
+      remainingPairs = remainingPairs - numPairs;
     }
-    catch(exception& e) {
-        m->errorOut(e, "PreClusterCommand", "createProcessesGroups");
-        exit(1);
+
+    //create array of worker threads
+    vector<thread*> workerThreads;
+    vector<preClusterData*> data;
+
+    auto synchronizedFastaFile = std::make_shared<SynchronizedOutputFile>(newFName);
+    auto synchronizedNameFile = std::make_shared<SynchronizedOutputFile>(newNName);
+
+    //Lauch worker threads
+    for (int i = 0; i < processors-1; i++) {
+      OutputWriter* threadFastaWriter = new OutputWriter(synchronizedFastaFile);
+      OutputWriter* threadNameWriter = new OutputWriter(synchronizedNameFile);
+
+      preClusterData* dataBundle = new preClusterData(fastafile, namefile, groupfile, countfile, pc_method, align_method, threadFastaWriter, threadNameWriter, newMFile, groups);
+      dataBundle->setVariables(lines[i+1].start, lines[i+1].end, diffs, pc_method, align_method, align, match, misMatch, gapOpen, gapExtend, alpha, delta, error_rate, indel_prob, max_indels, error_dist);
+      data.push_back(dataBundle);
+
+      workerThreads.push_back(new thread(driverGroups, dataBundle));
     }
+
+    OutputWriter* threadFastaWriter = new OutputWriter(synchronizedFastaFile);
+    OutputWriter* threadNameWriter = new OutputWriter(synchronizedNameFile);
+
+    preClusterData* dataBundle = new preClusterData(fastafile, namefile, groupfile, countfile, pc_method, align_method, threadFastaWriter, threadNameWriter, newMFile, groups);
+    dataBundle->setVariables(lines[0].start, lines[0].end, diffs, pc_method, align_method, align, match, misMatch, gapOpen, gapExtend, alpha, delta, error_rate, indel_prob, max_indels, error_dist);
+
+    driverGroups(dataBundle);
+
+    outputNames.insert(outputNames.end(), dataBundle->outputNames.begin(), dataBundle->outputNames.end());
+    outputTypes.insert(dataBundle->outputTypes.begin(), dataBundle->outputTypes.end());
+
+    for (int i = 0; i < processors-1; i++) {
+      workerThreads[i]->join();
+
+      delete data[i]->newFName;
+      delete data[i]->newNName;
+
+      outputNames.insert(outputNames.end(), data[i]->outputNames.begin(), data[i]->outputNames.end());
+      outputTypes.insert(data[i]->outputTypes.begin(), data[i]->outputTypes.end());
+
+      delete data[i];
+      delete workerThreads[i];
+    }
+    delete threadFastaWriter;
+    delete threadNameWriter;
+    delete dataBundle;
+
+  }
+  catch(exception& e) {
+      m->errorOut(e, "PreClusterCommand", "createProcessesGroups");
+      exit(1);
+  }
 }
+
 /**************************************************************************************************/

--- a/source/commands/preclustercommand.cpp
+++ b/source/commands/preclustercommand.cpp
@@ -647,12 +647,7 @@ int process(string group, string newMapFile, preClusterData* params){
 	  	if(numSeqs % 100 != 0)	{ params->m->mothurOut(group + toString(numSeqs) + "\t" + 	toString(numSeqs - count) + "\t" + toString(count) + "\n"); 	}
 
 		} else if(params->pc_method == "tree") {
-
-			if(params->delta > 1){
-				params->diffs = (int)(log(params->alignSeqs[0]->numIdentical)/log(params->delta) + 1);
-			} else {
-				params->diffs = params->length;
-			}
+			params->diffs = 1;
 
 			params->m->mothurOutJustToScreen("Determining which sequences can be merged...");
 			cout.flush();

--- a/source/commands/preclustercommand.cpp
+++ b/source/commands/preclustercommand.cpp
@@ -16,20 +16,20 @@ vector<string> PreClusterCommand::setParameters(){
 	try {
 		CommandParameter pfasta("fasta", "InputTypes", "", "", "none", "none", "none","fasta-name",false,true,true); parameters.push_back(pfasta);
 		CommandParameter pname("name", "InputTypes", "", "", "NameCount", "none", "none","name",false,false,true); parameters.push_back(pname);
-        CommandParameter pcount("count", "InputTypes", "", "", "NameCount-CountGroup", "none", "none","count",false,false,true); parameters.push_back(pcount);
+    CommandParameter pcount("count", "InputTypes", "", "", "NameCount-CountGroup", "none", "none","count",false,false,true); parameters.push_back(pcount);
 		CommandParameter pgroup("group", "InputTypes", "", "", "CountGroup", "none", "none","",false,false,true); parameters.push_back(pgroup);
 		CommandParameter pdiffs("diffs", "Number", "", "1", "", "", "","",false,false,true); parameters.push_back(pdiffs);
 		CommandParameter pprocessors("processors", "Number", "", "1", "", "", "","",false,false,true); parameters.push_back(pprocessors);
-        CommandParameter palign("align", "Multiple", "needleman-gotoh-blast-noalign", "needleman", "", "", "","",false,false); parameters.push_back(palign);
-        CommandParameter pmatch("match", "Number", "", "1.0", "", "", "","",false,false); parameters.push_back(pmatch);
-        CommandParameter pmismatch("mismatch", "Number", "", "-1.0", "", "", "","",false,false); parameters.push_back(pmismatch);
-        CommandParameter pgapopen("gapopen", "Number", "", "-2.0", "", "", "","",false,false); parameters.push_back(pgapopen);
-        CommandParameter pgapextend("gapextend", "Number", "", "-1.0", "", "", "","",false,false); parameters.push_back(pgapextend);
-
-        CommandParameter pmethod("method", "String", "", "simple", "", "", "","",false,false); parameters.push_back(pmethod);
+    CommandParameter palign("align", "Multiple", "needleman-gotoh-blast-noalign", "needleman", "", "", "","",false,false); parameters.push_back(palign);
+    CommandParameter pmatch("match", "Number", "", "1.0", "", "", "","",false,false); parameters.push_back(pmatch);
+    CommandParameter pmismatch("mismatch", "Number", "", "-1.0", "", "", "","",false,false); parameters.push_back(pmismatch);
+    CommandParameter pgapopen("gapopen", "Number", "", "-2.0", "", "", "","",false,false); parameters.push_back(pgapopen);
+    CommandParameter pgapextend("gapextend", "Number", "", "-1.0", "", "", "","",false,false); parameters.push_back(pgapextend);
+    CommandParameter palpha("alpha", "Number", "", "2.0", "", "", "","",false,false); parameters.push_back(palpha);
+    CommandParameter pmethod("method", "String", "", "simple", "", "", "","",false,false); parameters.push_back(pmethod);
 
 		CommandParameter pseed("seed", "Number", "", "0", "", "", "","",false,false); parameters.push_back(pseed);
-        CommandParameter pinputdir("inputdir", "String", "", "", "", "", "","",false,false); parameters.push_back(pinputdir);
+    CommandParameter pinputdir("inputdir", "String", "", "", "", "", "","",false,false); parameters.push_back(pinputdir);
 		CommandParameter poutputdir("outputdir", "String", "", "", "", "", "","",false,false); parameters.push_back(poutputdir);
 
 		vector<string> myArray;
@@ -50,14 +50,16 @@ string PreClusterCommand::getHelpString(){
 		helpString += "The pre.cluster command parameters are fasta, name, group, count, method, processors and diffs. The fasta parameter is required. \n";
 		helpString += "The name parameter allows you to give a list of seqs that are identical. This file is 2 columns, first column is name or representative sequence, second column is a list of its identical sequences separated by commas.\n";
 		helpString += "The group parameter allows you to provide a group file so you can cluster by group. \n";
-        helpString += "The count parameter allows you to provide a count file so you can cluster by group. \n";
+    helpString += "The count parameter allows you to provide a count file so you can cluster by group. \n";
 		helpString += "The diffs parameter allows you to specify maximum number of mismatched bases allowed between sequences in a grouping. The default is 1.\n";
-        helpString += "The method parameter allows you to specify the algorithm to use to complete the preclusterign step. Possible methods include simple, tree, unoise, and deblur.  Default=simple.\n";
-        helpString += "The align parameter allows you to specify the alignment align_method to use.  Your options are: gotoh, needleman, blast and noalign. The default is needleman.\n";
-        helpString += "The match parameter allows you to specify the bonus for having the same base. The default is 1.0.\n";
-        helpString += "The mistmatch parameter allows you to specify the penalty for having different bases.  The default is -1.0.\n";
-        helpString += "The gapopen parameter allows you to specify the penalty for opening a gap in an alignment. The default is -2.0.\n";
-        helpString += "The gapextend parameter allows you to specify the penalty for extending a gap in an alignment.  The default is -1.0.\n";
+    helpString += "The method parameter allows you to specify the algorithm to use to complete the preclusterign step. Possible methods include simple, tree, unoise, and deblur.  Default=simple.\n";
+    helpString += "The align parameter allows you to specify the alignment align_method to use.  Your options are: gotoh, needleman, blast and noalign. The default is needleman.\n";
+    helpString += "The match parameter allows you to specify the bonus for having the same base. The default is 1.0.\n";
+    helpString += "The mistmatch parameter allows you to specify the penalty for having different bases.  The default is -1.0.\n";
+    helpString += "The gapopen parameter allows you to specify the penalty for opening a gap in an alignment. The default is -2.0.\n";
+    helpString += "The gapextend parameter allows you to specify the penalty for extending a gap in an alignment.  The default is -1.0.\n";
+    helpString += "The alpha parameter allows you to specify the alpha value for the beta formula, which is used in the unoise algorithm. The default is 2.0.\n";
+
 		helpString += "The pre.cluster command should be in the following format: \n";
 		helpString += "pre.cluster(fasta=yourFastaFile, names=yourNamesFile, diffs=yourMaxDiffs) \n";
 		helpString += "Example pre.cluster(fasta=amazon.fasta, diffs=2).\n";
@@ -247,6 +249,10 @@ PreClusterCommand::PreClusterCommand(string option) {
       util.mothurConvert(temp, gapExtend);
       if (gapExtend > 0) { m->mothurOut("[ERROR]: gapextend must be negative.\n"); abort=true; }
 
+      temp = validParameter.valid(parameters, "alpha");	if (temp == "not found"){	temp = "2.0";			}
+      util.mothurConvert(temp, alpha);
+      if (alpha < 0) { m->mothurOut("[ERROR]: alpha must be positive.\n"); abort=true; }
+
       align = validParameter.valid(parameters, "align");		if (align == "not found"){	align = "needleman";	}
 
       align_method = "unaligned";
@@ -281,7 +287,9 @@ struct seqPNode {
 /************************************************************/
 
 inline bool comparePriorityTopDown(seqPNode* first, seqPNode* second) {
-  if (first->numIdentical > second->numIdentical) { return true;  }
+  if (first->numIdentical > second->numIdentical){
+ 		return true;
+	}
   return false;
 }
 
@@ -295,7 +303,7 @@ struct preClusterData {
   int start, end, count, diffs, length;
   vector<string> groups;
   bool hasCount, hasName;
-  float match, misMatch, gapOpen, gapExtend;
+  float match, misMatch, gapOpen, gapExtend, alpha;
   Utils util;
   vector<string> outputNames;
   map<string, vector<string> > outputTypes;
@@ -323,7 +331,7 @@ struct preClusterData {
     m = MothurOut::getInstance();
   }
 
-  void setVariables(int st, int en, int d, string pcm, string am, string al, float ma, float misma, float gpOp, float gpEx) {
+  void setVariables(int st, int en, int d, string pcm, string am, string al, float ma, float misma, float gpOp, float gpEx, float a) {
     start = st;
     end = en;
     diffs = d;
@@ -334,6 +342,7 @@ struct preClusterData {
     misMatch = misma;
     gapExtend = gpEx;
     gapOpen = gpOp;
+		alpha = a;
     length = 0;
 
     if (align_method == "unaligned") {
@@ -427,7 +436,7 @@ int process(string group, string newMapFile, preClusterData* params){
 
 	          if (params->m->getControl_pressed()) { out.close(); return 0; }
 
-	          if (params->alignSeqs[j]->active & (originalCount[j] < originalCount[i])) {  //this sequence has not been merged yet
+	          if (params->alignSeqs[j]->active && (originalCount[j] < originalCount[i])) {  //this sequence has not been merged yet
 	            //are you within "diff" bases
 	            int mismatch = params->length;
 	            if (params->align_method == "unaligned") {
@@ -459,14 +468,73 @@ int process(string group, string newMapFile, preClusterData* params){
 		      out << chunk;
 
 		     }//end if active i
-	      if(i % 100 == 0)	{ params->m->mothurOutJustToScreen(group + toString(i) + "\t" + toString(numSeqs - count) + "\t" + toString(count)+"\n"); 	}
+	      if(i % 100 == 0)	{
+					params->m->mothurOutJustToScreen(group + toString(i) + "\t" + toString(numSeqs - count) + "\t" + toString(count)+"\n");
+				}
 	    }
+ 		} else if(params->pc_method == "unoise") {
 
-		  out.close();
+			int maxDiffs = int((log2(originalCount[0])-1) / params->alpha + 1);
 
-		  if(numSeqs % 100 != 0)	{ params->m->mothurOut(group + toString(numSeqs) + "\t" + toString(numSeqs - count) + "\t" + toString(count) + "\n"); 	}
+			vector<double> beta(maxDiffs, 0);
+			for(int i=0;i<beta.size();i++){
+				beta[i] = pow(0.5, params->alpha * i + 1.0);
+			}
 
+			params->diffs = maxDiffs;
+
+	    for (int i = 0; i < numSeqs; i++) {
+
+	      if (params->alignSeqs[i]->active) {  //this sequence has not been merged yet
+
+	        string chunk = params->alignSeqs[i]->seq.getName() + "\t" + params->alignSeqs[i]->seq.getName() + "\t" + toString(params->alignSeqs[i]->numIdentical) + "\t" + toString(0) + "\t" + params->alignSeqs[i]->seq.getAligned() + "\n";
+
+	        //try to merge it with all smaller seqs
+	        for (int j = i+1; j < numSeqs; j++) {
+
+	          if (params->m->getControl_pressed()) { out.close(); return 0; }
+
+	          if (params->alignSeqs[j]->active && originalCount[j] < originalCount[i]) {  //this sequence has not been merged yet
+
+	            int mismatch = params->length;
+							double skew = (double)originalCount[j]/(double)originalCount[i];
+
+	            if (params->align_method == "unaligned") {
+								mismatch = calcMisMatches(params->alignSeqs[i]->seq.getAligned(),
+	 																				params->alignSeqs[j]->seq.getAligned(), params);
+							} else {
+								mismatch = calcMisMatches(params->alignSeqs[i]->filteredSeq,
+																					params->alignSeqs[j]->filteredSeq, params);
+							}
+
+	            if (mismatch <= maxDiffs && skew <= beta[mismatch]) { //merge
+	              params->alignSeqs[i]->names += ',' + params->alignSeqs[j]->names;
+	              params->alignSeqs[i]->numIdentical += params->alignSeqs[j]->numIdentical;
+
+	              chunk += params->alignSeqs[i]->seq.getName() + "\t" + params->alignSeqs[j]->seq.getName() + "\t" + toString(params->alignSeqs[j]->numIdentical) + "\t" + toString(mismatch) + "\t" + params->alignSeqs[j]->seq.getAligned() + "\n";
+
+	              params->alignSeqs[j]->active = 0;
+	              params->alignSeqs[j]->numIdentical = 0;
+	              params->alignSeqs[j]->diffs = mismatch;
+	              count++;
+	            }
+	          }//end if j active
+	        }//end for loop j
+
+		      //remove from active list
+		      params->alignSeqs[i]->active = 0;
+
+		      out << chunk;
+
+		    }//end if active i
+	      if(i % 100 == 0)	{ params->m->mothurOutJustToScreen(group + toString(i) + "\t" + toString(numSeqs - count) + "\t" + toString(count)+"\n"); 	}
+
+	    }
 		}
+
+	  out.close();
+
+	  if(numSeqs % 100 != 0)	{ params->m->mothurOut(group + toString(numSeqs) + "\t" + toString(numSeqs - count) + "\t" + toString(count) + "\n"); 	}
 
 		return count;
   }
@@ -555,7 +623,6 @@ vector<seqPNode*> readFASTA(CountTable ct, preClusterData* params, long long& nu
 
         //sort seqs by number of identical seqs
         sort(alignSeqs.begin(), alignSeqs.end(), comparePriorityTopDown);
-
         num = alignSeqs.size();
 
         return alignSeqs;
@@ -658,7 +725,7 @@ int PreClusterCommand::execute(){
             if (processors != 1) { m->mothurOut("When using running without group information mothur can only use 1 processor, continuing."); m->mothurOutEndLine(); processors = 1; }
 
             preClusterData* params = new preClusterData(fastafile, namefile, groupfile, countfile, pc_method, align_method, NULL, NULL, newMapFile, nullVector);
-            params->setVariables(0,0, diffs, pc_method, align_method, align, match, misMatch, gapOpen, gapExtend);
+            params->setVariables(0,0, diffs, pc_method, align_method, align, match, misMatch, gapOpen, gapExtend, alpha);
 
             //reads fasta file and return number of seqs
             long long numSeqs = 0; params->alignSeqs = readFASTA(ct, params, numSeqs); //fills alignSeqs and makes all seqs active
@@ -988,7 +1055,7 @@ void PreClusterCommand::createProcessesGroups(string newFName, string newNName, 
             OutputWriter* threadNameWriter = new OutputWriter(synchronizedNameFile);
 
             preClusterData* dataBundle = new preClusterData(fastafile, namefile, groupfile, countfile, pc_method, align_method, threadFastaWriter, threadNameWriter, newMFile, groups);
-            dataBundle->setVariables(lines[i+1].start, lines[i+1].end, diffs, pc_method, align_method, align, match, misMatch, gapOpen, gapExtend);
+            dataBundle->setVariables(lines[i+1].start, lines[i+1].end, diffs, pc_method, align_method, align, match, misMatch, gapOpen, gapExtend, alpha);
             data.push_back(dataBundle);
 
             workerThreads.push_back(new thread(driverGroups, dataBundle));
@@ -998,7 +1065,7 @@ void PreClusterCommand::createProcessesGroups(string newFName, string newNName, 
         OutputWriter* threadNameWriter = new OutputWriter(synchronizedNameFile);
 
         preClusterData* dataBundle = new preClusterData(fastafile, namefile, groupfile, countfile, pc_method, align_method, threadFastaWriter, threadNameWriter, newMFile, groups);
-        dataBundle->setVariables(lines[0].start, lines[0].end, diffs, pc_method, align_method, align, match, misMatch, gapOpen, gapExtend);
+        dataBundle->setVariables(lines[0].start, lines[0].end, diffs, pc_method, align_method, align, match, misMatch, gapOpen, gapExtend, alpha);
 
         driverGroups(dataBundle);
 

--- a/source/commands/preclustercommand.h
+++ b/source/commands/preclustercommand.h
@@ -46,15 +46,15 @@ public:
 	void help() { m->mothurOut(getHelpString()); }
 
 private:
-    CountTable ct;
+  CountTable ct;
 	int diffs, length, processors;
-    float match, misMatch, gapOpen, gapExtend;
+  float match, misMatch, gapOpen, gapExtend, alpha;
 	bool abort, bygroup;
 	string fastafile, namefile, outputDir, groupfile, countfile, pc_method, align_method, align;
 	vector<string> outputNames;
 
 	void createProcessesGroups(string, string, string);
-    int mergeGroupCounts(string, string, string);
+  int mergeGroupCounts(string, string, string);
 };
 
 

--- a/source/commands/preclustercommand.h
+++ b/source/commands/preclustercommand.h
@@ -26,33 +26,33 @@
 
 //************************************************************/
 class PreClusterCommand : public Command {
-	
+
 public:
 	PreClusterCommand(string);
 	PreClusterCommand();
 	~PreClusterCommand(){}
-	
+
 	vector<string> setParameters();
 	string getCommandName()			{ return "pre.cluster";				}
 	string getCommandCategory()		{ return "Sequence Processing";		}
-	
-	string getHelpString();	
-    string getOutputPattern(string);	
+
+	string getHelpString();
+    string getOutputPattern(string);
 	string getCitation() { return "Schloss PD, Gevers D, Westcott SL (2011).  Reducing the effects of PCR amplification and sequencing artifacts on 16S rRNA-based studies.  PLoS ONE.  6:e27310.\nhttp://www.mothur.org/wiki/Pre.cluster"; }
 	string getDescription()		{ return "implements a pseudo-single linkage algorithm with the goal of removing sequences that are likely due to pyrosequencing errors"; }
 
-	
-	int execute(); 
-	void help() { m->mothurOut(getHelpString()); }	
-	
+
+	int execute();
+	void help() { m->mothurOut(getHelpString()); }
+
 private:
     CountTable ct;
 	int diffs, length, processors;
     float match, misMatch, gapOpen, gapExtend;
-	bool abort, bygroup, topdown;
-	string fastafile, namefile, outputDir, groupfile, countfile, method, align;
+	bool abort, bygroup;
+	string fastafile, namefile, outputDir, groupfile, countfile, pc_method, align_method, align;
 	vector<string> outputNames;
-	
+
 	void createProcessesGroups(string, string, string);
     int mergeGroupCounts(string, string, string);
 };
@@ -61,5 +61,3 @@ private:
 /**************************************************************************************************/
 
 #endif
-
-

--- a/source/commands/preclustercommand.h
+++ b/source/commands/preclustercommand.h
@@ -41,14 +41,14 @@ public:
 	string getCitation() { return "Schloss PD, Gevers D, Westcott SL (2011).  Reducing the effects of PCR amplification and sequencing artifacts on 16S rRNA-based studies.  PLoS ONE.  6:e27310.\nhttp://www.mothur.org/wiki/Pre.cluster"; }
 	string getDescription()		{ return "implements a pseudo-single linkage algorithm with the goal of removing sequences that are likely due to pyrosequencing errors"; }
 
-
 	int execute();
 	void help() { m->mothurOut(getHelpString()); }
 
 private:
   CountTable ct;
 	int diffs, length, processors;
-  float match, misMatch, gapOpen, gapExtend, alpha, delta;
+  float match, misMatch, gapOpen, gapExtend, alpha, delta, error_rate, indel_prob, max_indels;
+	vector<float> error_dist;
 	bool abort, bygroup;
 	string fastafile, namefile, outputDir, groupfile, countfile, pc_method, align_method, align;
 	vector<string> outputNames;

--- a/source/commands/preclustercommand.h
+++ b/source/commands/preclustercommand.h
@@ -48,7 +48,7 @@ public:
 private:
   CountTable ct;
 	int diffs, length, processors;
-  float match, misMatch, gapOpen, gapExtend, alpha;
+  float match, misMatch, gapOpen, gapExtend, alpha, delta;
 	bool abort, bygroup;
 	string fastafile, namefile, outputDir, groupfile, countfile, pc_method, align_method, align;
 	vector<string> outputNames;

--- a/source/datastructures/counttable.cpp
+++ b/source/datastructures/counttable.cpp
@@ -21,35 +21,35 @@ int CountTable::createTable(set<string>& n, map<string, string>& g, set<string>&
         for (set<string>::iterator it = gs.begin(); it != gs.end(); it++) { groups.push_back(*it);  hasGroups = true; }
         numGroups = groups.size();
         totalGroups.resize(numGroups, 0);
-        
+
 		//sort groups to keep consistent with how we store the groups in groupmap
         sort(groups.begin(), groups.end());
         for (int i = 0; i < groups.size(); i++) {  indexGroupMap[groups[i]] = i; }
-        
+
         uniques = 0;
         total = 0;
         bool error = false;
         //n contains treenames
         for (set<string>::iterator it = n.begin(); it != n.end(); it++) {
-            
+
             if (m->getControl_pressed()) { break; }
-            
+
             string seqName = *it;
-            
+
             vector<int> groupCounts; groupCounts.resize(numGroups, 0);
             map<string, string>::iterator itGroup = g.find(seqName);
-            
-            if (itGroup != g.end()) {   
-                groupCounts[indexGroupMap[itGroup->second]] = 1; 
+
+            if (itGroup != g.end()) {
+                groupCounts[indexGroupMap[itGroup->second]] = 1;
                 totalGroups[indexGroupMap[itGroup->second]]++;
             }else {
                 //look for it in names of groups to see if the user accidently used the wrong file
                 if (util.inUsersGroups(seqName, groups)) {
                     m->mothurOut("[WARNING]: Your group or design file contains a group named " + seqName + ".  Perhaps you are used a group file instead of a design file? A common cause of this is using a tree file that relates your groups (created by the tree.shared command) with a group file that assigns sequences to a group.\n");
                 }
-                m->mothurOut("[ERROR]: Your group file does not contain " + seqName + ". Please correct.\n"); 
+                m->mothurOut("[ERROR]: Your group file does not contain " + seqName + ". Please correct.\n");
             }
-            
+
             map<string, int>::iterator it2 = indexNameMap.find(seqName);
             if (it2 == indexNameMap.end()) {
                 if (hasGroups) {  counts.push_back(groupCounts);  }
@@ -96,19 +96,19 @@ bool CountTable::testGroups(string file, vector<string>& groups) {
         m = MothurOut::getInstance(); hasGroups = false; total = 0;
         ifstream in;
         util.openInputFile(file, in);
-    
+
         string headers = util.getline(in); util.gobble(in);
         vector<string> columnHeaders = util.splitWhiteSpace(headers);
         if (columnHeaders.size() > 2) {
             hasGroups = true;
-        
+
             for (int i = 2; i < columnHeaders.size(); i++) {
                 groups.push_back(columnHeaders[i]);
             }
             //sort groups to keep consistent with how we store the groups in groupmap
             sort(groups.begin(), groups.end());
         }
-        
+
         return hasGroups;
     }
 	catch(exception& e) {
@@ -116,7 +116,9 @@ bool CountTable::testGroups(string file, vector<string>& groups) {
 		exit(1);
 	}
 }
+
 /************************************************************/
+
 bool CountTable::setNamesOfGroups(vector<string> mygroups) {
     try {
         //remove groups from table not in new groups we are setting
@@ -124,13 +126,13 @@ bool CountTable::setNamesOfGroups(vector<string> mygroups) {
             if (util.inUsersGroups(groups[i], mygroups)) {}
             else { removeGroup(groups[i]);  }
         }
-        
+
         //add any new groups in new groups list to table
         for (int i = 0; i < mygroups.size(); i++) {
             if (util.inUsersGroups(mygroups[i], groups)) {}
             else { addGroup(mygroups[i]);  }
         }
-        
+
         //false if error
         return (!m->getControl_pressed());
     }
@@ -139,12 +141,14 @@ bool CountTable::setNamesOfGroups(vector<string> mygroups) {
         exit(1);
     }
 }
+
 /************************************************************/
+
 int CountTable::createTable(string namefile, string groupfile, bool createGroup) {
     try {
-        
+
         if (namefile == "") { m->mothurOut("[ERROR]: namefile cannot be blank when creating a count table.\n"); m->setControl_pressed(true); }
-                                           
+
         GroupMap* groupMap;
         int numGroups = 0;
         groups.clear();
@@ -153,8 +157,8 @@ int CountTable::createTable(string namefile, string groupfile, bool createGroup)
         indexNameMap.clear();
         counts.clear();
         map<int, string> originalGroupIndexes;
-        
-        if (groupfile != "") { 
+
+        if (groupfile != "") {
             hasGroups = true;
             groupMap = new GroupMap(groupfile); groupMap->readMap();
             numGroups = groupMap->getNumGroups();
@@ -169,44 +173,44 @@ int CountTable::createTable(string namefile, string groupfile, bool createGroup)
 		//sort groups to keep consistent with how we store the groups in groupmap
         sort(groups.begin(), groups.end());
         for (int i = 0; i < groups.size(); i++) {  indexGroupMap[groups[i]] = i; }
-        
+
         bool error = false;
         string name;
         uniques = 0;
         total = 0;
-        
-        
+
+
         //open input file
         ifstream in;
         util.openInputFile(namefile, in);
-        
+
         int total = 0;
         while (!in.eof()) {
             if (m->getControl_pressed()) { break; }
-            
+
             string firstCol, secondCol;
             in >> firstCol; util.gobble(in); in >> secondCol; util.gobble(in);
-            
+
             util.checkName(firstCol);
             util.checkName(secondCol);
-            
+
             vector<string> names;
             util.splitAtChar(secondCol, names, ',');
-            
+
             map<string, int> groupCounts;
             int thisTotal = 0;
             if (groupfile != "") {
                 //set to 0
                 for (int i = 0; i < groups.size(); i++) { groupCounts[groups[i]] = 0; }
-                
+
                 //get counts for each of the users groups
                 for (int i = 0; i < names.size(); i++) {
                     string group = groupMap->getGroup(names[i]);
-                    
+
                     if (group == "not found") { m->mothurOut("[ERROR]: " + names[i] + " is not in your groupfile, please correct."); m->mothurOutEndLine(); error=true; }
                     else {
                         map<string, int>::iterator it = groupCounts.find(group);
-                        
+
                         //if not found, then this sequence is not from a group we care about
                         if (it != groupCounts.end()) {
                             it->second++;
@@ -221,14 +225,14 @@ int CountTable::createTable(string namefile, string groupfile, bool createGroup)
                     groupCounts["Group1"]++; thisTotal++;
                 }
             }else { thisTotal = names.size();  }
-            
+
             //if group info, then read it
             vector<int> thisGroupsCount; thisGroupsCount.resize(numGroups, 0);
-            for (int i = 0; i < numGroups; i++) {  
-                thisGroupsCount[i] = groupCounts[groups[i]]; 
-                totalGroups[i] += thisGroupsCount[i]; 
+            for (int i = 0; i < numGroups; i++) {
+                thisGroupsCount[i] = groupCounts[groups[i]];
+                totalGroups[i] += thisGroupsCount[i];
             }
-            
+
             map<string, int>::iterator it = indexNameMap.find(firstCol);
             if (it == indexNameMap.end()) {
                 if (hasGroups) {  counts.push_back(thisGroupsCount);  }
@@ -238,11 +242,11 @@ int CountTable::createTable(string namefile, string groupfile, bool createGroup)
                 uniques++;
             }else {
                 error = true;
-                m->mothurOut("[ERROR]: Your count table contains more than 1 sequence named " + firstCol + ", sequence names must be unique. Please correct."); m->mothurOutEndLine(); 
+                m->mothurOut("[ERROR]: Your count table contains more than 1 sequence named " + firstCol + ", sequence names must be unique. Please correct."); m->mothurOutEndLine();
             }
         }
         in.close();
-		
+
         if (error) { m->setControl_pressed(true); }
         else { //check for zero groups
             if (hasGroups) {
@@ -252,7 +256,7 @@ int CountTable::createTable(string namefile, string groupfile, bool createGroup)
             }
         }
         if (groupfile != "") { delete groupMap; }
-        
+
         return 0;
     }
 	catch(exception& e) {
@@ -267,7 +271,7 @@ int CountTable::readTable(string file, string format) {
             filename = file;
             ifstream in;
             util.openInputFile(filename, in);
-            
+
             hasGroups = false;
             groups.clear();
             totalGroups.clear();
@@ -278,13 +282,13 @@ int CountTable::readTable(string file, string format) {
             uniques = 0;
             total = 0;
             while (!in.eof()) {
-                
+
                 if (m->getControl_pressed()) { break; }
-                
+
                 Sequence seq(in); util.gobble(in);
                 string name = seq.getName();
                 if (m->getDebug()) { m->mothurOut("[DEBUG]: " + name + '\t' + toString(1) + "\n"); }
-                
+
                 map<string, int>::iterator it = indexNameMap.find(name);
                 if (it == indexNameMap.end()) {
                     indexNameMap[name] = uniques;
@@ -297,10 +301,10 @@ int CountTable::readTable(string file, string format) {
                 }
             }
             in.close();
-            
+
             if (error) { m->setControl_pressed(true); }
         }else { m->mothurOut("[ERROR]: Unsupported format: " + format + ", please correct.\n"); m->setControl_pressed(true);  }
-        
+
         return total;
     }
     catch(exception& e) {
@@ -315,10 +319,10 @@ int CountTable::readTable(string file, bool readGroups, bool mothurRunning) {
         filename = file;
         ifstream in;
         util.openInputFile(filename, in);
-        
+
         string headers = util.getline(in); util.gobble(in);
         vector<string> columnHeaders = util.splitWhiteSpace(headers);
-        
+
         int numGroups = 0;
         groups.clear();
         totalGroups.clear();
@@ -331,22 +335,22 @@ int CountTable::readTable(string file, bool readGroups, bool mothurRunning) {
         //sort groups to keep consistent with how we store the groups in groupmap
         sort(groups.begin(), groups.end());
         for (int i = 0; i < groups.size(); i++) {  indexGroupMap[groups[i]] = i; }
-        
+
         bool error = false;
         string name;
         int thisTotal;
         uniques = 0;
         total = 0;
         while (!in.eof()) {
-            
+
             if (m->getControl_pressed()) { break; }
-            
+
             in >> name; util.gobble(in); in >> thisTotal; util.gobble(in);
             if (m->getDebug()) { m->mothurOut("[DEBUG]: " + name + '\t' + toString(thisTotal) + "\n"); }
-            
+
             if ((thisTotal == 0) && !mothurRunning) { error=true; m->mothurOut("[ERROR]: Your count table contains a sequence named " + name + " with a total=0. Please correct."); m->mothurOutEndLine();
             }
-            
+
             //if group info, then read it
             vector<int> groupCounts; groupCounts.resize(numGroups, 0);
             if (columnHeaders.size() > 2) { //file contains groups
@@ -356,7 +360,7 @@ int CountTable::readTable(string file, bool readGroups, bool mothurRunning) {
                     util.getline(in); util.gobble(in);
                 }
             }
-            
+
             map<string, int>::iterator it = indexNameMap.find(name);
             if (it == indexNameMap.end()) {
                 if (hasGroups) {  counts.push_back(groupCounts);  }
@@ -366,11 +370,11 @@ int CountTable::readTable(string file, bool readGroups, bool mothurRunning) {
                 uniques++;
             }else {
                 error = true;
-                m->mothurOut("[ERROR]: Your count table contains more than 1 sequence named " + name + ", sequence names must be unique. Please correct.\n");  
+                m->mothurOut("[ERROR]: Your count table contains more than 1 sequence named " + name + ", sequence names must be unique. Please correct.\n");
             }
         }
         in.close();
-        
+
         if (error) { m->setControl_pressed(true); }
         else { //check for zero groups
             if (hasGroups) {
@@ -379,7 +383,7 @@ int CountTable::readTable(string file, bool readGroups, bool mothurRunning) {
                 }
             }
         }
-        
+
         return 0;
     }
 	catch(exception& e) {
@@ -387,21 +391,43 @@ int CountTable::readTable(string file, bool readGroups, bool mothurRunning) {
 		exit(1);
 	}
 }
+
+/************************************************************/
+
+int CountTable::clearTable() {
+  try {
+
+		for(int i=0;i<counts.size();i++){
+			for(int j=0;j<counts[0].size();j++){
+				counts[i][j] = 0;
+			}
+		}
+
+		totals.assign(totals.size(), 0);
+
+		return 0;
+	}
+	catch(exception& e) {
+		m->errorOut(e, "CountTable", "readTable");
+		exit(1);
+	}
+}
+
 /************************************************************/
 int CountTable::printTable(string file) {
     try {
         ofstream out;
-        util.openOutputFile(file, out); 
+        util.openOutputFile(file, out);
 		out << "Representative_Sequence\ttotal";
         if (hasGroups) {  for (int i = 0; i < groups.size(); i++) { out << '\t' << groups[i]; }  }
         out << endl;
-        
+
         map<int, string> reverse; //use this to preserve order
         for (map<string, int>::iterator it = indexNameMap.begin(); it !=indexNameMap.end(); it++) { reverse[it->second] = it->first;  }
-        
+
         for (int i = 0; i < totals.size(); i++) {
             map<int, string>::iterator itR = reverse.find(i);
-            
+
             if (itR != reverse.end()) { //will equal end if seqs were removed because remove just removes from indexNameMap
                 out << itR->second << '\t' << totals[i];
                 if (hasGroups) {
@@ -450,7 +476,7 @@ int CountTable::printSeq(ofstream& out, string seqName) {
 		map<string, int>::iterator it = indexNameMap.find(seqName);
         if (it == indexNameMap.end()) {
             m->mothurOut("[ERROR]: " + seqName + " is not in your count table. Please correct.\n"); m->setControl_pressed(true);
-        }else { 
+        }else {
             out << it->first << '\t' << totals[it->second];
             if (hasGroups) {
                 for (int i = 0; i < groups.size(); i++) {
@@ -479,11 +505,11 @@ vector<int> CountTable::getGroupCounts(string seqName) {
                     m->mothurOut("[WARNING]: Your group or design file contains a group named " + seqName + ".  Perhaps you are used a group file instead of a design file? A common cause of this is using a tree file that relates your groups (created by the tree.shared command) with a group file that assigns sequences to a group."); m->mothurOutEndLine();
                 }
                 m->mothurOut("[ERROR]: " + seqName + " is not in your count table. Please correct.\n"); m->setControl_pressed(true);
-            }else { 
+            }else {
                 temp = counts[it->second];
             }
         }else{  m->mothurOut("[ERROR]: Your count table does not have group info. Please correct.\n"); m->setControl_pressed(true); }
-        
+
         return temp;
     }
 	catch(exception& e) {
@@ -499,7 +525,7 @@ int CountTable::getGroupCount(string groupName) {
             map<string, int>::iterator it = indexGroupMap.find(groupName);
             if (it == indexGroupMap.end()) {
                 m->mothurOut("[ERROR]: group " + groupName + " is not in your count table. Please correct.\n"); m->setControl_pressed(true);
-            }else { 
+            }else {
                 return totalGroups[it->second];
             }
         }else{  m->mothurOut("[ERROR]: Your count table does not have group info. Please correct.\n");  m->setControl_pressed(true); }
@@ -519,7 +545,7 @@ int CountTable::getGroupCount(string seqName, string groupName) {
             map<string, int>::iterator it = indexGroupMap.find(groupName);
             if (it == indexGroupMap.end()) {
                 m->mothurOut("[ERROR]: group " + groupName + " is not in your count table. Please correct.\n"); m->setControl_pressed(true);
-            }else { 
+            }else {
                 map<string, int>::iterator it2 = indexNameMap.find(seqName);
                 if (it2 == indexNameMap.end()) {
                     //look for it in names of groups to see if the user accidently used the wrong file
@@ -527,12 +553,12 @@ int CountTable::getGroupCount(string seqName, string groupName) {
                         m->mothurOut("[WARNING]: Your group or design file contains a group named " + seqName + ".  Perhaps you are used a group file instead of a design file? A common cause of this is using a tree file that relates your groups (created by the tree.shared command) with a group file that assigns sequences to a group."); m->mothurOutEndLine();
                     }
                     m->mothurOut("[ERROR]: seq " + seqName + " is not in your count table. Please correct.\n"); m->setControl_pressed(true);
-                }else { 
+                }else {
                     return counts[it2->second][it->second];
                 }
             }
         }else{  m->mothurOut("[ERROR]: Your count table does not have group info. Please correct.\n");  m->setControl_pressed(true); }
-        
+
         return 0;
     }
 	catch(exception& e) {
@@ -548,7 +574,7 @@ int CountTable::setAbund(string seqName, string groupName, int num) {
             map<string, int>::iterator it = indexGroupMap.find(groupName);
             if (it == indexGroupMap.end()) {
                 m->mothurOut("[ERROR]: " + groupName + " is not in your count table. Please correct.\n"); m->setControl_pressed(true);
-            }else { 
+            }else {
                 map<string, int>::iterator it2 = indexNameMap.find(seqName);
                 if (it2 == indexNameMap.end()) {
                     //look for it in names of groups to see if the user accidently used the wrong file
@@ -556,7 +582,7 @@ int CountTable::setAbund(string seqName, string groupName, int num) {
                         m->mothurOut("[WARNING]: Your group or design file contains a group named " + seqName + ".  Perhaps you are used a group file instead of a design file? A common cause of this is using a tree file that relates your groups (created by the tree.shared command) with a group file that assigns sequences to a group."); m->mothurOutEndLine();
                     }
                     m->mothurOut("[ERROR]: " + seqName + " is not in your count table. Please correct.\n"); m->setControl_pressed(true);
-                }else { 
+                }else {
                     int oldCount = counts[it2->second][it->second];
                     counts[it2->second][it->second] = num;
                     totalGroups[it->second] += (num - oldCount);
@@ -565,7 +591,7 @@ int CountTable::setAbund(string seqName, string groupName, int num) {
                 }
             }
         }else{  m->mothurOut("[ERROR]: Your count table does not have group info. Please correct.\n");  m->setControl_pressed(true); }
-        
+
         return 0;
     }
 	catch(exception& e) {
@@ -576,35 +602,35 @@ int CountTable::setAbund(string seqName, string groupName, int num) {
 /************************************************************/
 //add group
 int CountTable::addGroup(string groupName) {
-    try {        
+    try {
         bool sanity = util.inUsersGroups(groupName, groups);
         if (sanity) { m->mothurOut("[ERROR]: " + groupName + " is already in the count table, cannot add again.\n"); m->setControl_pressed(true);  return 0; }
-        
+
         groups.push_back(groupName);
         if (!hasGroups) { counts.resize(uniques);  }
-        
+
         for (int i = 0; i < counts.size(); i++) { counts[i].push_back(0); }
         totalGroups.push_back(0);
         indexGroupMap[groupName] = groups.size()-1;
         map<string, int> originalGroupMap = indexGroupMap;
-        
+
         //important to play well with others, :)
         sort(groups.begin(), groups.end());
-        
+
         //fix indexGroupMap && totalGroups
         vector<int> newTotals; newTotals.resize(groups.size(), 0);
-        for (int i = 0; i < groups.size(); i++) {  
-            indexGroupMap[groups[i]] = i;  
+        for (int i = 0; i < groups.size(); i++) {
+            indexGroupMap[groups[i]] = i;
             //find original spot of group[i]
             int index = originalGroupMap[groups[i]];
             newTotals[i] = totalGroups[index];
         }
         totalGroups = newTotals;
-        
+
         //fix counts vectors
         for (int i = 0; i < counts.size(); i++) {
             vector<int> newCounts; newCounts.resize(groups.size(), 0);
-            for (int j = 0; j < groups.size(); j++) {  
+            for (int j = 0; j < groups.size(); j++) {
                 //find original spot of group[i]
                 int index = originalGroupMap[groups[j]];
                 newCounts[j] = counts[i][index];
@@ -612,7 +638,7 @@ int CountTable::addGroup(string groupName) {
             counts[i] = newCounts;
         }
         hasGroups = true;
-        
+
         return 0;
     }
 	catch(exception& e) {
@@ -623,21 +649,21 @@ int CountTable::addGroup(string groupName) {
 /************************************************************/
 //remove group
 int CountTable::removeGroup(string groupName) {
-    try {        
+    try {
         if (hasGroups) {
             //save for later in case removing a group means we need to remove a seq.
             map<int, string> reverse;
             for (map<string, int>::iterator it = indexNameMap.begin(); it !=indexNameMap.end(); it++) { reverse[it->second] = it->first;  }
-            
+
             map<string, int>::iterator it = indexGroupMap.find(groupName);
             if (it == indexGroupMap.end()) {
                 m->mothurOut("[ERROR]: " + groupName + " is not in your count table. Please correct.\n"); m->setControl_pressed(true);
-            }else { 
+            }else {
                 int indexOfGroupToRemove = it->second;
                 map<string, int> currentGroupIndex = indexGroupMap;
                 vector<string> newGroups;
                 for (int i = 0; i < groups.size(); i++) {
-                    if (groups[i] != groupName) { 
+                    if (groups[i] != groupName) {
                         newGroups.push_back(groups[i]);
                         indexGroupMap[groups[i]] = newGroups.size()-1;
                     }
@@ -645,7 +671,7 @@ int CountTable::removeGroup(string groupName) {
                 indexGroupMap.erase(groupName);
                 groups = newGroups;
                 totalGroups.erase(totalGroups.begin()+indexOfGroupToRemove);
-                
+
                 int thisIndex = 0;
                 map<string, int> newIndexNameMap;
                 for (int i = 0; i < counts.size(); i++) {
@@ -663,11 +689,11 @@ int CountTable::removeGroup(string groupName) {
                     thisIndex++;
                 }
                 indexNameMap = newIndexNameMap;
-                
+
                 if (groups.size() == 0) { hasGroups = false; }
             }
         }else { m->mothurOut("[ERROR]: your count table does not contain group information, can not remove group " + groupName + ".\n"); m->setControl_pressed(true); }
-    
+
         return 0;
     }
 	catch(exception& e) {
@@ -682,11 +708,11 @@ vector<string> CountTable::getGroups(string seqName) {
         vector<string> thisGroups;
         if (hasGroups) {
             vector<int> thisCounts = getGroupCounts(seqName);
-            for (int i = 0; i < thisCounts.size(); i++) {  
+            for (int i = 0; i < thisCounts.size(); i++) {
                 if (thisCounts[i] != 0) {  thisGroups.push_back(groups[i]); }
-            } 
+            }
         }else{  m->mothurOut("[ERROR]: Your count table does not have group info. Please correct.\n");  m->setControl_pressed(true); }
-        
+
         return thisGroups;
     }
 	catch(exception& e) {
@@ -698,7 +724,7 @@ vector<string> CountTable::getGroups(string seqName) {
 //total number of seqs represented by seq
 int CountTable::renameSeq(string oldSeqName, string newSeqName) {
     try {
-        
+
         map<string, int>::iterator it = indexNameMap.find(oldSeqName);
         if (it == indexNameMap.end()) {
             if (hasGroupInfo()) {
@@ -708,12 +734,12 @@ int CountTable::renameSeq(string oldSeqName, string newSeqName) {
                 }
             }
             m->mothurOut("[ERROR]: " + oldSeqName + " is not in your count table. Please correct.\n"); m->setControl_pressed(true);
-        }else {  
+        }else {
             int index = it->second;
             indexNameMap.erase(it);
             indexNameMap[newSeqName] = index;
         }
-        
+
         return 0;
     }
 	catch(exception& e) {
@@ -726,7 +752,7 @@ int CountTable::renameSeq(string oldSeqName, string newSeqName) {
 //total number of seqs represented by seq
 int CountTable::getNumSeqs(string seqName) {
     try {
-                
+
         map<string, int>::iterator it = indexNameMap.find(seqName);
         if (it == indexNameMap.end()) {
             if (hasGroupInfo()) {
@@ -736,7 +762,7 @@ int CountTable::getNumSeqs(string seqName) {
                 }
             }
             m->mothurOut("[ERROR]: " + seqName + " is not in your count table. Please correct.\n"); m->setControl_pressed(true);
-        }else { 
+        }else {
             return totals[it->second];
         }
 
@@ -751,7 +777,7 @@ int CountTable::getNumSeqs(string seqName) {
 //set total number of seqs represented by seq
 int CountTable::setNumSeqs(string seqName, int abund) {
     try {
-        
+
         map<string, int>::iterator it = indexNameMap.find(seqName);
         if (it == indexNameMap.end()) {
             m->mothurOut("[ERROR]: " + seqName + " is not in your count table. Please correct.\n"); m->setControl_pressed(true); return -1;
@@ -760,7 +786,7 @@ int CountTable::setNumSeqs(string seqName, int abund) {
             totals[it->second] = abund;
             total-=diff;
         }
-        
+
         return 0;
     }
     catch(exception& e) {
@@ -773,7 +799,7 @@ int CountTable::setNumSeqs(string seqName, int abund) {
 //returns unique index for sequence like get in NameAssignment
 int CountTable::get(string seqName) {
     try {
-        
+
         map<string, int>::iterator it = indexNameMap.find(seqName);
         if (it == indexNameMap.end()) {
             if (hasGroupInfo()) {
@@ -784,7 +810,7 @@ int CountTable::get(string seqName) {
             }
             m->mothurOut("[ERROR]: " + seqName + " is not in your count table. Please correct.\n"); m->setControl_pressed(true);
         }else { return it->second; }
-        
+
         return -1;
     }
 	catch(exception& e) {
@@ -806,7 +832,7 @@ int CountTable::push_back(string seqName) {
         }else {
             m->mothurOut("[ERROR]: Your count table contains more than 1 sequence named " + seqName + ", sequence names must be unique. Please correct."); m->mothurOutEndLine(); m->setControl_pressed(true);
         }
-        
+
         return 1;
     }
 	catch(exception& e) {
@@ -836,7 +862,7 @@ int CountTable::remove(string seqName) {
             }
             m->mothurOut("[ERROR]: Your count table contains does not include " + seqName + ", cannot remove."); m->mothurOutEndLine(); m->setControl_pressed(true);
         }
-        
+
         return 0;
     }
 	catch(exception& e) {
@@ -858,7 +884,7 @@ int CountTable::push_back(string seqName, int thisTotal) {
         }else {
             m->mothurOut("[ERROR]: Your count table contains more than 1 sequence named " + seqName + ", sequence names must be unique. Please correct."); m->mothurOutEndLine(); m->setControl_pressed(true);
         }
-        
+
         return thisTotal;
     }
 	catch(exception& e) {
@@ -874,7 +900,7 @@ int CountTable::push_back(string seqName, vector<int> groupCounts) {
         map<string, int>::iterator it = indexNameMap.find(seqName);
         if (it == indexNameMap.end()) {
             if ((hasGroups) && (groupCounts.size() != getNumGroups())) {  m->mothurOut("[ERROR]: Your count table has a " + toString(getNumGroups()) + " groups and " + seqName + " has " + toString(groupCounts.size()) + ", please correct."); m->mothurOutEndLine(); m->setControl_pressed(true);  }
-            
+
             for (int i = 0; i < getNumGroups(); i++) {   totalGroups[i] += groupCounts[i];  thisTotal += groupCounts[i]; }
             if (hasGroups) {  counts.push_back(groupCounts);  }
             indexNameMap[seqName] = uniques;
@@ -884,7 +910,7 @@ int CountTable::push_back(string seqName, vector<int> groupCounts) {
         }else {
             m->mothurOut("[ERROR]: Your count table contains more than 1 sequence named " + seqName + ", sequence names must be unique. Please correct."); m->mothurOutEndLine(); m->setControl_pressed(true);
         }
-        
+
         return thisTotal;
     }
 	catch(exception& e) {
@@ -898,9 +924,9 @@ int CountTable::push_back(string seqName, vector<int> groupCounts) {
 ListVector CountTable::getListVector() {
     try {
         ListVector list(indexNameMap.size());
-        for (map<string, int>::iterator it = indexNameMap.begin(); it != indexNameMap.end(); it++) { 
+        for (map<string, int>::iterator it = indexNameMap.begin(); it != indexNameMap.end(); it++) {
             if (m->getControl_pressed()) { break; }
-            list.set(it->second, it->first); 
+            list.set(it->second, it->first);
         }
         return list;
     }
@@ -918,7 +944,7 @@ vector<string> CountTable::getNamesOfSeqs() {
         for (map<string, int>::iterator it = indexNameMap.begin(); it != indexNameMap.end(); it++) {
             names.push_back(it->first);
         }
-                
+
         return names;
     }
 	catch(exception& e) {
@@ -934,7 +960,7 @@ map<string, int> CountTable::getNameMap() {
         for (map<string, int>::iterator it = indexNameMap.begin(); it != indexNameMap.end(); it++) {
             names[it->first] = totals[it->second];
         }
-        
+
         return names;
     }
 	catch(exception& e) {
@@ -951,13 +977,13 @@ vector<string> CountTable::getNamesOfSeqs(string group) {
             map<string, int>::iterator it = indexGroupMap.find(group);
             if (it == indexGroupMap.end()) {
                 m->mothurOut("[ERROR]: " + group + " is not in your count table. Please correct.\n"); m->setControl_pressed(true);
-            }else { 
+            }else {
                 for (map<string, int>::iterator it2 = indexNameMap.begin(); it2 != indexNameMap.end(); it2++) {
                     if (counts[it2->second][it->second] != 0) {  names.push_back(it2->first); }
                 }
             }
         }else{  m->mothurOut("[ERROR]: Your count table does not have group info. Please correct.\n");  m->setControl_pressed(true); }
-        
+
         return names;
     }
 	catch(exception& e) {
@@ -978,7 +1004,7 @@ int CountTable::mergeCounts(string seq1, string seq2) {
                 }
             }
             m->mothurOut("[ERROR]: " + seq1 + " is not in your count table. Please correct.\n"); m->setControl_pressed(true);
-        }else { 
+        }else {
             map<string, int>::iterator it2 = indexNameMap.find(seq2);
             if (it2 == indexNameMap.end()) {
                 if (hasGroupInfo()) {
@@ -988,12 +1014,12 @@ int CountTable::mergeCounts(string seq1, string seq2) {
                     }
                 }
                 m->mothurOut("[ERROR]: " + seq2 + " is not in your count table. Please correct.\n"); m->setControl_pressed(true);
-            }else { 
+            }else {
                 //merge data
                 for (int i = 0; i < groups.size(); i++) { counts[it->second][i] += counts[it2->second][i]; }
                 totals[it->second] += totals[it2->second];
                 uniques--;
-                indexNameMap.erase(it2); 
+                indexNameMap.erase(it2);
             }
         }
         return 0;
@@ -1009,12 +1035,12 @@ int CountTable::copy(CountTable* ct) {
         vector<string> thisGroups = ct->getNamesOfGroups();
         for (int i = 0; i < thisGroups.size(); i++) { addGroup(thisGroups[i]); }
         vector<string> names = ct->getNamesOfSeqs();
-                                                               
+
         for (int i = 0; i < names.size(); i++) {
             vector<int> thisCounts = ct->getGroupCounts(names[i]);
             push_back(names[i], thisCounts);
         }
-                                                               
+
         return 0;
     }
 	catch(exception& e) {
@@ -1024,5 +1050,3 @@ int CountTable::copy(CountTable* ct) {
 }
 
 /************************************************************/
-
-

--- a/source/datastructures/counttable.h
+++ b/source/datastructures/counttable.h
@@ -14,15 +14,15 @@
 //count table files look like:
 
 /*
- Representative_Sequence	total	F003D000	F003D002	F003D004	F003D006	F003D008	F003D142	F003D144	F003D146	F003D148	F003D150	MOCK.GQY1XT001	
- GQY1XT001C296C	6051	409	985	923	937	342	707	458	439	387	464	0	
- GQY1XT001A3TJI	4801	396	170	413	442	306	769	581	576	497	651	0	
- GQY1XT001CS2B8	3018	263	226	328	460	361	336	248	290	187	319	0	
- GQY1XT001CD9IB	2736	239	177	256	405	306	286	263	248	164	392	0	
- 
+ Representative_Sequence	total	F003D000	F003D002	F003D004	F003D006	F003D008	F003D142	F003D144	F003D146	F003D148	F003D150	MOCK.GQY1XT001
+ GQY1XT001C296C	6051	409	985	923	937	342	707	458	439	387	464	0
+ GQY1XT001A3TJI	4801	396	170	413	442	306	769	581	576	497	651	0
+ GQY1XT001CS2B8	3018	263	226	328	460	361	336	248	290	187	319	0
+ GQY1XT001CD9IB	2736	239	177	256	405	306	286	263	248	164	392	0
+
  or if no group info was used to create it
- 
- Representative_Sequence	total	
+
+ Representative_Sequence	total
  GQY1XT001C296C	6051
  GQY1XT001A3TJI	4801
  GQY1XT001CS2B8	3018
@@ -31,8 +31,8 @@
  GQY1XT001CNF2P	2796
  GQY1XT001CJMDA	1667
  GQY1XT001CBVJB	3758
- 
- 
+
+
  */
 
 
@@ -42,18 +42,19 @@
 #include "sequence.hpp"
 
 class CountTable {
-    
+
     public:
-    
+
         CountTable() { m = MothurOut::getInstance(); hasGroups = false; total = 0; uniques = 0; }
         ~CountTable() {}
-    
-        //reads and creates smart enough to eliminate groups with zero counts 
-        int createTable(set<string>&, map<string, string>&, set<string>&); //seqNames, seqName->group, groupNames 
+
+        //reads and creates smart enough to eliminate groups with zero counts
+        int createTable(set<string>&, map<string, string>&, set<string>&); //seqNames, seqName->group, groupNames
         int createTable(string, string, bool); //namefile, groupfile, createGroup
         int readTable(string, bool, bool); //filename, readGroups, mothurRunning
         int readTable(string, string); //filename, format - if format=fasta, read fasta file and create unique table
-    
+        int clearTable(); //turn all counts to zeros
+
         int printTable(string);
         int printHeaders(ofstream&);
         vector<string> getHardCodedHeaders(); //Representative_Sequence, total
@@ -61,23 +62,23 @@ class CountTable {
         bool testGroups(string file); //used to check if file has group data without reading it
         bool testGroups(string file, vector<string>&); //used to check if file has group data without reading it, return groups if found.
         int copy(CountTable*);
-    
+
         bool hasGroupInfo() { return hasGroups; }
         int getNumGroups() { return (int)groups.size(); }
         vector<string> getNamesOfGroups() {  return groups;   }  //returns group names, if no group info vector is blank.
         bool setNamesOfGroups(vector<string>);
         int addGroup(string);
         int removeGroup(string);
-        
+
         int renameSeq(string, string); //used to change name of sequence for use with trees
         int setAbund(string, string, int); //set abundance number of seqs for that group for that seq
-        int push_back(string); //add a sequence 
-        int push_back(string, int); //add a sequence 
+        int push_back(string); //add a sequence
+        int push_back(string, int); //add a sequence
         int push_back(string, vector<int>); //add a sequence with group info
         int remove(string); //remove seq
         int get(string); //returns unique sequence index for reading distance matrices like NameAssignment
         int size() { return (int)indexNameMap.size(); }
-    
+
         vector<string> getGroups(string); //returns vector of groups represented by this sequences
         vector<int> getGroupCounts(string);  //returns group counts for a seq passed in, if no group info is in file vector is blank. Order is the same as the groups returned by getGroups function.
         int getGroupCount(string, string); //returns number of seqs for that group for that seq
@@ -87,13 +88,13 @@ class CountTable {
         int getNumSeqs() { return total; } //return total number of seqs
         int getNumUniqueSeqs() { return uniques; } //return number of unique/representative seqs
         int getGroupIndex(string); //returns index in getGroupCounts vector of specific group
-    
+
         vector<string> getNamesOfSeqs();
         vector<string> getNamesOfSeqs(string);
         int mergeCounts(string, string); //combines counts for 2 seqs, saving under the first name passed in.
         ListVector getListVector();
         map<string, int> getNameMap();  //sequenceName -> total number of sequences it represents
-    
+
     private:
         string filename;
         MothurOut* m;
@@ -106,7 +107,7 @@ class CountTable {
         vector<int> totalGroups;
         map<string, int> indexNameMap;
         map<string, int> indexGroupMap;
-    
+
 };
 
 #endif

--- a/source/summary.cpp
+++ b/source/summary.cpp
@@ -33,17 +33,17 @@ void Summary::processNameCount(string n) { //name or count file to include in co
 bool Summary::isCountFile(string inputfile){
     try {
         bool isCount = true;
-        
+
         ifstream in;
         Utils util; util.openInputFile(inputfile, in);
-        
+
         //read headers
         string line = util.getline(in);
-        
+
         in.close();
-        
+
         vector<string> pieces = util.splitWhiteSpace(line);
-        
+
         if (pieces.size() >= 2) {
             CountTable ct;
             vector<string> defaultHeaders = ct.getHardCodedHeaders();
@@ -52,8 +52,8 @@ bool Summary::isCountFile(string inputfile){
                 if (pieces[1] != defaultHeaders[1]) { isCount = false; }
             }else { isCount = false; }
         }else { isCount = false; }
-        
-        
+
+
         return isCount;
     }
     catch(exception& e) {
@@ -66,17 +66,17 @@ bool Summary::isCountFile(string inputfile){
 vector<long long> Summary::getDefaults() {
     try {
         vector<long long> locations;
-        
+
         long long ptile0_25	= 1+(long long)(total * 0.025); //number of sequences at 2.5%
         long long ptile25		= 1+(long long)(total * 0.250); //number of sequences at 25%
         long long ptile50		= 1+(long long)(total * 0.500);
         long long ptile75		= 1+(long long)(total * 0.750);
         long long ptile97_5	= 1+(long long)(total * 0.975);
         long long ptile100	= (long long)(total);
-        
+
         locations.push_back(1); locations.push_back(ptile0_25); locations.push_back(ptile25); locations.push_back(ptile50);
         locations.push_back(ptile75); locations.push_back(ptile97_5); locations.push_back(ptile100);
-        
+
         return locations;
     }
     catch(exception& e) {
@@ -92,12 +92,12 @@ vector<long long> Summary::getValues(map<int, long long>& positions) {
         long long meanPosition; meanPosition = 0;
         long long totalSoFar = 0;
         int lastValue = 0;
-        
+
         //minimum
         if ((positions.begin())->first == -1) { results[0] = 0; }
         else {results[0] = (positions.begin())->first; }
         results[1] = results[0]; results[2] = results[0]; results[3] = results[0]; results[4] = results[0]; results[5] = results[0];
-        
+
         for (map<int, long long>::iterator it = positions.begin(); it != positions.end(); it++) {
             int value = it->first; if (value == -1) { value = 0; }
             meanPosition += (value*it->second);
@@ -111,10 +111,10 @@ vector<long long> Summary::getValues(map<int, long long>& positions) {
             lastValue = totalSoFar;
         }
         results[6] = (positions.rbegin())->first;
-        
+
         double meansPosition = meanPosition / (double) total;
         results.push_back(meansPosition);
-        
+
         return results;
     }
     catch(exception& e) {
@@ -129,19 +129,19 @@ long long Summary::getValue(map<int, long long>& spots, double value) {
         long long result = 0;
         long long totalSoFar = 0;
         long long lastValue = 0;
-        
+
         //minimum
         if ((spots.begin())->first == -1) { result = 0; }
         else {result = (spots.begin())->first; }
-    
+
         for (it = spots.begin(); it != spots.end(); it++) {
             long long value = it->first; if (value == -1) { value = 0; }
             totalSoFar += it->second;
-            
+
             if (((totalSoFar <= percentage) && (totalSoFar > 1)) || ((lastValue < percentage) && (totalSoFar > percentage))){  result = value;   } //save value
             lastValue = totalSoFar;
         }
-        
+
         return result;
     }
     catch(exception& e) {
@@ -157,12 +157,12 @@ vector<long long> Summary::getValues(map<float, long long>& positions) {
         long long meanPosition; meanPosition = 0;
         long long totalSoFar = 0;
         int lastValue = 0;
-        
+
         //minimum
         if ((positions.begin())->first == -1) { results[0] = 0; }
         else {results[0] = (positions.begin())->first; }
         results[1] = results[0]; results[2] = results[0]; results[3] = results[0]; results[4] = results[0]; results[5] = results[0];
-        
+
         for (map<float, long long>::iterator it = positions.begin(); it != positions.end(); it++) {
             long long value = it->first; if (value == -1) { value = 0; }
             meanPosition += (value*it->second);
@@ -176,10 +176,10 @@ vector<long long> Summary::getValues(map<float, long long>& positions) {
             lastValue = totalSoFar;
         }
         results[6] = (positions.rbegin())->first;
-        
+
         double meansPosition = meanPosition / (double) total;
         results.push_back(meansPosition);
-        
+
         return results;
     }
     catch(exception& e) {
@@ -194,19 +194,19 @@ long long Summary::getValue(map<float, long long>& positions, double value) {
         long long result = 0;
         long long totalSoFar = 0;
         long long lastValue = 0;
-        
+
         //minimum
         if ((positions.begin())->first == -1) { result = 0; }
         else { result = (positions.begin())->first; }
-        
+
         for (map<float, long long>::iterator it = positions.begin(); it != positions.end(); it++) {
             long long value = it->first; if (value == -1) { value = 0; }
             totalSoFar += it->second;
-            
+
             if (((totalSoFar <= percentage) && (totalSoFar > 1)) || ((lastValue < percentage) && (totalSoFar > percentage))){  result = value;   } //save value
             lastValue = totalSoFar;
         }
-        
+
         return result;
     }
     catch(exception& e) {
@@ -214,7 +214,25 @@ long long Summary::getValue(map<float, long long>& positions, double value) {
         exit(1);
     }
 }
-//**********************************************************************************************************************
+
+//**************************************************************************************************
+
+int Summary::getMaxAbundance(){
+
+	int max = 0;
+
+	for(map<string,int>::iterator it=nameMap.begin();it!=nameMap.end();it++){
+		if(it->second > max){
+			max = it->second;
+		}
+	}
+
+	return max;
+
+}
+
+//**************************************************************************************************
+
 long long Summary::summarizeFasta(string fastafile, string n, string output) {
     try {
         //fill namemap
@@ -231,86 +249,86 @@ void driverSummarize(seqSumData* params) { //(string fastafile, string output, l
     try {
         ofstream out;
         if (params->summaryFile != "") { params->util.openOutputFile(params->summaryFile, out); }
-        
+
         ifstream in;
         params->util.openInputFile(params->filename, in);
-        
+
         in.seekg(params->start);
-        
+
         //print header if you are process 0
         if (params->start == 0) {
             params->util.zapGremlins(in); params->util.gobble(in);
             //print header if you are process 0
             if (params->summaryFile != "") { out << "seqname\tstart\tend\tnbases\tambigs\tpolymer\tnumSeqs" << endl; }
         }
-        
+
         bool done = false;
         params->count = 0;
-        
+
         while (!done) {
-            
+
             if (params->m->getControl_pressed()) {  break; }
-            
+
             Sequence seq(in); params->util.gobble(in);
-            
+
             if (seq.getName() != "") {
-                
+
                 if (params->m->getDebug()) { params->m->mothurOut("[DEBUG]: " + seq.getName() + "\t" + toString(seq.getStartPos()) + "\t" + toString(seq.getEndPos()) + "\t" + toString(seq.getNumBases()) + "\n"); }
-                
+
                 //string seqInfo = addSeq(current);
                 params->count++;
-                
+
                 long long num = 1;
-                
+
                 if (params->hasNameMap) {
                     //make sure this sequence is in the namefile, else error
                     map<string, int>::iterator itFindName = params->nameMap.find(seq.getName());
-                    
+
                     if (itFindName == params->nameMap.end()) { params->m->mothurOut("[ERROR]: '" + seq.getName() + "' is not in your name or count file, please correct."); params->m->mothurOutEndLine(); params->m->setControl_pressed(true); }
                     else { num = itFindName->second; }
                 }
-                
+
                 int thisStartPosition = seq.getStartPos();
                 map<int, long long>::iterator it = params->startPosition.find(thisStartPosition);
                 if (it == params->startPosition.end()) { params->startPosition[thisStartPosition] = num; } //first finding of this start position, set count.
                 else { it->second += num; } //add counts
-                
+
                 int thisEndPosition = seq.getEndPos();
                 it = params->endPosition.find(thisEndPosition);
                 if (it == params->endPosition.end()) { params->endPosition[thisEndPosition] = num; } //first finding of this end position, set count.
                 else { it->second += num; } //add counts
-                
+
                 int thisSeqLength = seq.getNumBases();
                 it = params->seqLength.find(thisSeqLength);
                 if (it == params->seqLength.end()) { params->seqLength[thisSeqLength] = num; } //first finding of this length, set count.
                 else { it->second += num; } //add counts
-                
+
                 int thisAmbig = seq.getAmbigBases();
                 it = params->ambigBases.find(thisAmbig);
                 if (it == params->ambigBases.end()) { params->ambigBases[thisAmbig] = num; } //first finding of this ambig, set count.
                 else { it->second += num; } //add counts
-                
+
                 int thisHomoP = seq.getLongHomoPolymer();
                 it = params->longHomoPolymer.find(thisHomoP);
                 if (it == params->longHomoPolymer.end()) { params->longHomoPolymer[thisHomoP] = num; } //first finding of this homop, set count.
                 else { it->second += num; } //add counts
-                
+
                 int numns = seq.getNumNs();
                 it = params->numNs.find(numns);
                 if (it == params->numNs.end()) { params->numNs[numns] = num; } //first finding of this homop, set count.
                 else { it->second += num; } //add counts
-                
+
                 params->total += num;
-                
+
                 string seqInfo = "";
                 seqInfo += seq.getName() + '\t';
                 seqInfo += toString(thisStartPosition) + '\t' + toString(thisEndPosition) + '\t';
                 seqInfo += toString(thisSeqLength) + '\t' + toString(thisAmbig) + '\t';
                 seqInfo += toString(thisHomoP) + '\t' + toString(num);
-                
+
                 if (params->summaryFile != "") { out << seqInfo << endl; }
             }
-            
+
 #if defined NON_WINDOWS
             unsigned long long pos = in.tellg();
             if ((pos == -1) || (pos >= params->end)) { break; }
@@ -318,10 +336,10 @@ void driverSummarize(seqSumData* params) { //(string fastafile, string output, l
             if (params->count == params->end) { break; }
 #endif
         }
-        
+
         if (params->summaryFile != "") { out.close(); }
         in.close();
-        
+
     }
     catch(exception& e) {
         params->m->errorOut(e, "Summary", "driverSummarize");
@@ -340,7 +358,7 @@ long long Summary::summarizeFasta(string fastafile, string output) {
 #else
         positions = util.setFilePosFasta(fastafile, num);
         if (num < processors) { processors = num; }
-        
+
         //figure out how many sequences you have to process
         int numSeqsPerProcessor = num / processors;
         for (int i = 0; i < processors; i++) {
@@ -349,7 +367,7 @@ long long Summary::summarizeFasta(string fastafile, string output) {
             lines.push_back(linePair(positions[startIndex], numSeqsPerProcessor));
         }
 #endif
-        
+
         //create array of worker threads
         vector<thread*> workerThreads;
         vector<seqSumData*> data;
@@ -360,15 +378,15 @@ long long Summary::summarizeFasta(string fastafile, string output) {
             extension = toString(i) + ".temp";
             string outputName = output + extension;
             if (output == "") {  outputName = "";  }
-            
+
             seqSumData* dataBundle = new seqSumData(fastafile, outputName, lines[i+1].start, lines[i+1].end, hasNameOrCount, nameMap);
             data.push_back(dataBundle);
-            
+
             workerThreads.push_back(new thread(driverSummarize, dataBundle));
         }
-        
+
         seqSumData* dataBundle = new seqSumData(fastafile, output, lines[0].start, lines[0].end, hasNameOrCount, nameMap);
-        
+
         driverSummarize(dataBundle);
         num = dataBundle->count;
         total = dataBundle->total;
@@ -379,12 +397,12 @@ long long Summary::summarizeFasta(string fastafile, string output) {
         longHomoPolymer = dataBundle->longHomoPolymer;
         numNs = dataBundle->numNs;
         delete dataBundle;
-        
+
         for (int i = 0; i < processors-1; i++) {
             workerThreads[i]->join();
             num += data[i]->count;
             total += data[i]->total;
-            
+
             for (map<int, long long>::iterator it = data[i]->startPosition.begin(); it != data[i]->startPosition.end(); it++)		{
                 map<int, long long>::iterator itMain = startPosition.find(it->first);
                 if (itMain == startPosition.end()) { //newValue
@@ -425,7 +443,7 @@ long long Summary::summarizeFasta(string fastafile, string output) {
             delete data[i];
             delete workerThreads[i];
         }
-        
+
         //append files
         for (int i = 0; i < processors-1; i++) {
             string extension = "";
@@ -438,17 +456,17 @@ long long Summary::summarizeFasta(string fastafile, string output) {
                 util.mothurRemove((output + toString(i) + ".temp"));
             }
         }
-        
+
         if (hasNameOrCount) {
             if (nameCountNumUniques != num) { // do fasta and name/count files match
                 m->mothurOut("[ERROR]: Your " + type + " file contains " + toString(nameCountNumUniques) + " unique sequences, but your fasta file contains " + toString(num) + ". File mismatch detected, quitting command.\n"); m->setControl_pressed(true);
             }
         }
-        
+
         numUniques = num;
-        
+
         return num;
-        
+
     }
     catch(exception& e) {
         m->errorOut(e, "Summary", "summarizeFasta");
@@ -472,59 +490,59 @@ void driverFastaSummarySummarize(seqSumData* params) {
     try {
         ifstream in;
         params->util.openInputFile(params->filename, in);
-        
+
         in.seekg(params->start);
-        
+
         //print header if you are process 0
         if (params->start == 0) { params->util.zapGremlins(in); params->util.getline(in); params->util.gobble(in); params->count++; }
-        
+
         bool done = false;
         string name;
         int start, end, length, ambigs, polymer;
         long long numReps;
-        
+
         while (!done) {
-            
+
             if (params->m->getControl_pressed()) {  break; }
-            
+
             //seqname	start	end	nbases	ambigs	polymer	numSeqs
             in >> name >> start >> end >> length >> ambigs >> polymer >> numReps; params->util.gobble(in);
-            
+
             if (params->m->getDebug()) { params->m->mothurOut("[DEBUG]: " + name + "\t" + toString(start) + "\t" + toString(end) + "\t" + toString(length) + "\n"); }
-            
+
             if (name != "") {
                 if ((numReps == 1) && params->hasNameMap) {
                     //make sure this sequence is in the namefile, else error
                     map<string, int>::iterator itFindName = params->nameMap.find(name);
-                    
+
                     if (itFindName == params->nameMap.end()) { params->m->mothurOut("[ERROR]: '" + name + "' is not in your name or count file, please correct."); params->m->mothurOutEndLine(); params->m->setControl_pressed(true); }
                     else { numReps = itFindName->second; }
                 }
-                
+
                 map<int, long long>::iterator it = params->startPosition.find(start);
                 if (it == params->startPosition.end()) { params->startPosition[start] = numReps; } //first finding of this start position, set count.
                 else { it->second += numReps; } //add counts
-                
+
                 it = params->endPosition.find(end);
                 if (it == params->endPosition.end()) { params->endPosition[end] = numReps; } //first finding of this end position, set count.
                 else { it->second += numReps; } //add counts
-                
+
                 it = params->seqLength.find(length);
                 if (it == params->seqLength.end()) { params->seqLength[length] = numReps; } //first finding of this length, set count.
                 else { it->second += numReps; } //add counts
-                
+
                 it = params->ambigBases.find(ambigs);
                 if (it == params->ambigBases.end()) { params->ambigBases[ambigs] = numReps; } //first finding of this ambig, set count.
                 else { it->second += numReps; } //add counts
-                
+
                 it = params->longHomoPolymer.find(polymer);
                 if (it == params->longHomoPolymer.end()) { params->longHomoPolymer[polymer] = numReps; } //first finding of this homop, set count.
                 else { it->second += numReps; } //add counts
-                
+
                 params->count++;
                 params->total += numReps;
             }
-            
+
 #if defined NON_WINDOWS
             unsigned long long pos = in.tellg();
             if ((pos == -1) || (pos >= params->end)) { break; }
@@ -532,9 +550,9 @@ void driverFastaSummarySummarize(seqSumData* params) {
             if (params->end == params->count) { break; }
 #endif
         }
-        
+
         in.close();
-        
+
     }
     catch(exception& e) {
         params-> m->errorOut(e, "Summary", "driverFastaSummarySummarize");
@@ -553,7 +571,7 @@ long long Summary::summarizeFastaSummary(string summaryfile) {
 #else
         positions = util.setFilePosEachLine(summaryfile, num);
         if (num < processors) { processors = num; }
-        
+
         //figure out how many sequences you have to process
         int numSeqsPerProcessor = num / processors;
         for (int i = 0; i < processors; i++) {
@@ -562,21 +580,21 @@ long long Summary::summarizeFastaSummary(string summaryfile) {
             lines.push_back(linePair(positions[startIndex], numSeqsPerProcessor));
         }
 #endif
-        
+
         //create array of worker threads
         vector<thread*> workerThreads;
         vector<seqSumData*> data;
-        
+
         //Lauch worker threads
         for (int i = 0; i < processors-1; i++) {
             seqSumData* dataBundle = new seqSumData(summaryfile, lines[i+1].start, lines[i+1].end, hasNameOrCount, nameMap);
             data.push_back(dataBundle);
-            
+
             workerThreads.push_back(new thread(driverFastaSummarySummarize, dataBundle));
         }
-        
+
         seqSumData* dataBundle = new seqSumData(summaryfile, lines[0].start, lines[0].end, hasNameOrCount, nameMap);
-        
+
         driverFastaSummarySummarize(dataBundle);
         num = dataBundle->count-1; //header line
         total = dataBundle->total;
@@ -586,12 +604,12 @@ long long Summary::summarizeFastaSummary(string summaryfile) {
         ambigBases = dataBundle->ambigBases;
         longHomoPolymer = dataBundle->longHomoPolymer;
         delete dataBundle;
-        
+
         for (int i = 0; i < processors-1; i++) {
             workerThreads[i]->join();
             num += data[i]->count;
             total += data[i]->total;
-            
+
             for (map<int, long long>::iterator it = data[i]->startPosition.begin(); it != data[i]->startPosition.end(); it++)		{
                 map<int, long long>::iterator itMain = startPosition.find(it->first);
                 if (itMain == startPosition.end()) { //newValue
@@ -622,20 +640,20 @@ long long Summary::summarizeFastaSummary(string summaryfile) {
                     longHomoPolymer[it->first] = it->second;
                 }else { itMain->second += it->second; } //merge counts
             }
-            
+
             delete data[i];
             delete workerThreads[i];
         }
-        
-        
+
+
         if (hasNameOrCount) {
             if (nameCountNumUniques != num) { // do fasta and name/count files match
                 m->mothurOut("[ERROR]: Your " + type + " file contains " + toString(nameCountNumUniques) + " unique sequences, but your fasta file contains " + toString(num) + ". File mismatch detected, quitting command.\n"); m->setControl_pressed(true);
             }
         }
-        
+
         numUniques = num;
-        
+
         return num;
 
     }
@@ -661,64 +679,64 @@ void driverContigsSummarySummarize(seqSumData* params) {
     try {
         ifstream in;
         params->util.openInputFile(params->filename, in);
-        
+
         in.seekg(params->start);
-        
+
         //print header if you are process 0
         if (params->start == 0) { params->util.zapGremlins(in); params->util.getline(in); params->util.gobble(in); params->count++; }
-        
+
         bool done = false;
         string name;
         int length, OLength, thisOStart, thisOEnd, numMisMatches, numns; //Name	Length	Overlap_Length	Overlap_Start	Overlap_End	MisMatches	Num_Ns
         double expectedErrors;
-        
+
         while (!done) {
-            
+
             if (params->m->getControl_pressed()) { break; }
-            
+
             //seqname	start	end	nbases	ambigs	polymer	numSeqs
             in >> name >> length >> OLength >> thisOStart >> thisOEnd >> numMisMatches >> numns >> expectedErrors; params->util.gobble(in);
-            
+
             if (params->m->getDebug()) { params->m->mothurOut("[DEBUG]: " + name + "\t" + toString(thisOStart) + "\t" + toString(thisOEnd) + "\t" + toString(length) + "\n"); }
-            
+
             if (name != "") {
                 long long numReps = 1;
                 if (params->hasNameMap) {
                     //make sure this sequence is in the namefile, else error
                     map<string, int>::iterator itFindName = params->nameMap.find(name);
-                    
+
                     if (itFindName == params->nameMap.end()) { params->m->mothurOut("[ERROR]: '" + name + "' is not in your name or count file, please correct."); params->m->mothurOutEndLine(); params->m->setControl_pressed(true); }
                     else { numReps = itFindName->second; }
                 }
-                
+
                 map<int, long long>::iterator it = params->ostartPosition.find(thisOStart);
                 if (it == params->ostartPosition.end()) { params->ostartPosition[thisOStart] = numReps; } //first finding of this start position, set count.
                 else { it->second += numReps; } //add counts
-                
+
                 it = params->oendPosition.find(thisOEnd);
                 if (it == params->oendPosition.end()) { params->oendPosition[thisOEnd] = numReps; } //first finding of this end position, set count.
                 else { it->second += numReps; } //add counts
-                
+
                 it = params->oseqLength.find(OLength);
                 if (it == params->oseqLength.end()) { params->oseqLength[OLength] = numReps; } //first finding of this length, set count.
                 else { it->second += numReps; } //add counts
-                
+
                 it = params->seqLength.find(length);
                 if (it == params->seqLength.end()) { params->seqLength[length] = numReps; } //first finding of this length, set count.
                 else { it->second += numReps; } //add counts
-                
+
                 it = params->misMatches.find(numMisMatches);
                 if (it == params->misMatches.end()) { params->misMatches[numMisMatches] = numReps; } //first finding of this ambig, set count.
                 else { it->second += numReps; } //add counts
-                
+
                 it = params->numNs.find(numns);
                 if (it == params->numNs.end()) { params->numNs[numns] = numReps; } //first finding of this homop, set count.
                 else { it->second += numReps; } //add counts
-                
+
                 params->count++;
                 params->total += numReps;
             }
-            
+
 #if defined NON_WINDOWS
             unsigned long long pos = in.tellg();
             if ((pos == -1) || (pos >= params->end)) { break; }
@@ -726,7 +744,7 @@ void driverContigsSummarySummarize(seqSumData* params) {
             if (params->end == params->count) { break; }
 #endif
         }
-        
+
         in.close();
     }
     catch(exception& e) {
@@ -746,7 +764,7 @@ long long Summary::summarizeContigsSummary(string summaryfile) {
 #else
         positions = util.setFilePosEachLine(summaryfile, num);
         if (num < processors) { processors = num; }
-        
+
         //figure out how many sequences you have to process
         int numSeqsPerProcessor = num / processors;
         for (int i = 0; i < processors; i++) {
@@ -755,22 +773,22 @@ long long Summary::summarizeContigsSummary(string summaryfile) {
             lines.push_back(linePair(positions[startIndex], numSeqsPerProcessor));
         }
 #endif
-        
+
         //create array of worker threads
         vector<thread*> workerThreads;
         vector<seqSumData*> data;
-        
+
         //Lauch worker threads
         for (int i = 0; i < processors-1; i++) {
             if (m->getDebug()) { m->mothurOut("[DEBUG]: creating thread " + toString(i+1) + "\n"); }
             seqSumData* dataBundle = new seqSumData(summaryfile, lines[i+1].start, lines[i+1].end, hasNameOrCount, nameMap);
             data.push_back(dataBundle);
-            
+
             workerThreads.push_back(new thread(driverContigsSummarySummarize, dataBundle));
         }
-        
+
         seqSumData* dataBundle = new seqSumData(summaryfile, lines[0].start, lines[0].end, hasNameOrCount, nameMap);
-        
+
         driverContigsSummarySummarize(dataBundle);
         num = dataBundle->count-1; //header line
         total = dataBundle->total;
@@ -781,14 +799,14 @@ long long Summary::summarizeContigsSummary(string summaryfile) {
         misMatches = dataBundle->misMatches;
         numNs = dataBundle->numNs;
         delete dataBundle;
-        
-        
+
+
         for (int i = 0; i < processors-1; i++) {
             workerThreads[i]->join();
             num += data[i]->count;
             total += data[i]->total;
-            
-            
+
+
             for (map<int, long long>::iterator it = data[i]->ostartPosition.begin(); it != data[i]->ostartPosition.end(); it++)		{
                 map<int, long long>::iterator itMain = ostartPosition.find(it->first);
                 if (itMain == ostartPosition.end()) { //newValue
@@ -825,20 +843,20 @@ long long Summary::summarizeContigsSummary(string summaryfile) {
                     numNs[it->first] = it->second;
                 }else { itMain->second += it->second; } //merge counts
             }
-            
+
             delete data[i];
             delete workerThreads[i];
         }
-        
-        
+
+
         if (hasNameOrCount) {
             if (nameCountNumUniques != num) { // do fasta and name/count files match
                 m->mothurOut("[ERROR]: Your " + type + " file contains " + toString(nameCountNumUniques) + " unique sequences, but your fasta file contains " + toString(num) + ". File mismatch detected, quitting command.\n"); m->setControl_pressed(true);
             }
         }
-        
+
         numUniques = num;
-        
+
         return num;
     }
     catch(exception& e) {
@@ -863,58 +881,58 @@ void driverAlignSummarySummarize(seqSumData* params) {
     try {
         ifstream in;
         params->util.openInputFile(params->filename, in);
-        
+
         in.seekg(params->start);
-        
+
         //print header if you are process 0
         if (params->start == 0) { params->util.zapGremlins(in); params->util.getline(in); params->util.gobble(in); params->count++; }
-        
+
         bool done = false;
         string name, TemplateName, SearchMethod, AlignmentMethod;
         int length, TemplateLength,	 QueryStart,	QueryEnd,	TemplateStart,	TemplateEnd,	PairwiseAlignmentLength,	GapsInQuery,	GapsInTemplate,	LongestInsert;
         float SearchScore, SimBtwnQueryTemplate;
-        
+
         while (!done) {
-            
+
             if (params->m->getControl_pressed()) {  break; }
-            
+
             in >> name >> length >> TemplateName >> TemplateLength >> SearchMethod >> SearchScore >> AlignmentMethod >> QueryStart >> QueryEnd >> TemplateStart >> TemplateEnd >> PairwiseAlignmentLength >> GapsInQuery >> GapsInTemplate >> LongestInsert >> SimBtwnQueryTemplate; params->util.gobble(in);
-            
-            
+
+
             if (params->m->getDebug()) { params->m->mothurOut("[DEBUG]: " + name + "\t" + toString(TemplateName) + "\t" + toString(SearchScore) + "\t" + toString(length) + "\n"); }
-            
+
             if (name != "") {
                 //string seqInfo = addSeq(name, length, SimBtwnQueryTemplate, SearchScore, LongestInsert);
                 long long numReps = 1;
                 if (params->hasNameMap) {
                     //make sure this sequence is in the namefile, else error
                      map<string, int>::iterator itFindName = params->nameMap.find(name);
-                    
+
                     if (itFindName == params->nameMap.end()) { params->m->mothurOut("[ERROR]: '" + name + "' is not in your name or count file, please correct."); params->m->mothurOutEndLine(); params->m->setControl_pressed(true); }
                     else { numReps = itFindName->second; }
                 }
-                
+
                 map<float, long long>:: iterator itFloat = params->sims.find(SimBtwnQueryTemplate);
                 if (itFloat == params->sims.end()) { params->sims[SimBtwnQueryTemplate] = numReps; } //first finding of this similarity score, set count.
                 else { itFloat->second += numReps; } //add counts
-                
+
                 itFloat = params->scores.find(SearchScore);
                 if (itFloat == params->scores.end()) { params->scores[SearchScore] = numReps; } //first finding of this end position, set count.
                 else { itFloat->second += numReps; } //add counts
-                
+
                 map<int, long long>::iterator it = params->inserts.find(LongestInsert);
                 if (it == params->inserts.end()) { params->inserts[LongestInsert] = numReps; } //first finding of this length, set count.
                 else { it->second += numReps; } //add counts
-                
+
                 it = params->seqLength.find(length);
                 if (it == params->seqLength.end()) { params->seqLength[length] = numReps; } //first finding of this length, set count.
                 else { it->second += numReps; } //add counts
-                
+
                 params->count++;
                 params->total += numReps;
 
             }
-            
+
 #if defined NON_WINDOWS
             unsigned long long pos = in.tellg();
             if ((pos == -1) || (pos >= params->end)) { break; }
@@ -922,7 +940,7 @@ void driverAlignSummarySummarize(seqSumData* params) {
             if (params->end == params->count) { break; }
 #endif
         }
-        
+
         in.close();
     }
     catch(exception& e) {
@@ -942,7 +960,7 @@ long long Summary::summarizeAlignSummary(string summaryfile) {
 #else
         positions = util.setFilePosEachLine(summaryfile, num);
         if (num < processors) { processors = num; }
-        
+
         //figure out how many sequences you have to process
         int numSeqsPerProcessor = num / processors;
         for (int i = 0; i < processors; i++) {
@@ -954,18 +972,18 @@ long long Summary::summarizeAlignSummary(string summaryfile) {
         //create array of worker threads
         vector<thread*> workerThreads;
         vector<seqSumData*> data;
-        
+
         //Lauch worker threads
         for (int i = 0; i < processors-1; i++) {
-            
+
             seqSumData* dataBundle = new seqSumData(summaryfile, lines[i+1].start, lines[i+1].end, hasNameOrCount, nameMap);
             data.push_back(dataBundle);
-            
+
             workerThreads.push_back(new thread(driverAlignSummarySummarize, dataBundle));
         }
-        
+
         seqSumData* dataBundle = new seqSumData(summaryfile, lines[0].start, lines[0].end, hasNameOrCount, nameMap);
-        
+
         driverAlignSummarySummarize(dataBundle);
         num = dataBundle->count-1; //header line
         total = dataBundle->total;
@@ -974,12 +992,12 @@ long long Summary::summarizeAlignSummary(string summaryfile) {
         inserts = dataBundle->inserts;
         seqLength = dataBundle->seqLength;
         delete dataBundle;
-        
+
         for (int i = 0; i < processors-1; i++) {
             workerThreads[i]->join();
             num += data[i]->count;
             total += data[i]->total;
-            
+
             for (map<float, long long>::iterator it = data[i]->sims.begin(); it != data[i]->sims.end(); it++)		{
                 map<float, long long>::iterator itMain = sims.find(it->first);
                 if (itMain == sims.end()) { //newValue
@@ -1004,20 +1022,20 @@ long long Summary::summarizeAlignSummary(string summaryfile) {
                     seqLength[it->first] = it->second;
                 }else { itMain->second += it->second; } //merge counts
             }
-            
+
             delete data[i];
             delete workerThreads[i];
         }
-        
-        
+
+
         if (hasNameOrCount) {
             if (nameCountNumUniques != num) { // do fasta and name/count files match
                 m->mothurOut("[ERROR]: Your " + type + " file contains " + toString(nameCountNumUniques) + " unique sequences, but your fasta file contains " + toString(num) + ". File mismatch detected, quitting command.\n"); m->setControl_pressed(true);
             }
         }
-        
+
         numUniques = num;
-        
+
         return num;
     }
     catch(exception& e) {
@@ -1026,10 +1044,3 @@ long long Summary::summarizeAlignSummary(string summaryfile) {
     }
 }
 //**********************************************************************************************************************
-
-
-
-
-
-
-

--- a/source/summary.hpp
+++ b/source/summary.hpp
@@ -14,16 +14,16 @@
 #include "counttable.h"
 
 class Summary {
-    
+
 public:
-    
+
 #ifdef UNIT_TEST
     friend class TestSummary;
 #endif
-    
+
     Summary(int p) { processors = p; m = MothurOut::getInstance(); total = 0; numUniques = 0; hasNameOrCount = false; nameCountNumUniques = 0; type = "count"; }
     ~Summary() {}
-    
+
     long long summarizeFasta(string f, string n, string o); //provide fasta file to summarize (paralellized) and optional nameorCountfile and optional outputfile for individual seqs info. To skip nameCount or output file, n="" and / or o=""
     long long summarizeFasta(string f, string o); //provide fasta file to summarize (paralellized) and optional outputfile for individual seqs info. To skip output file, o=""
     long long summarizeFastaSummary(string f); //provide summary of fasta file to summarize (paralellized)
@@ -45,7 +45,7 @@ public:
     long long getLength(double value) { return (getValue(seqLength, value)); } // 25 = min length of 25% of sequences
     vector<long long> getHomop() { return (getValues(longHomoPolymer)); } //returns vector of 8 locations. (min, 2.5, 25, 50, 75, 97.5, max, mean)
     long long getHomop(double value) { return (getValue(longHomoPolymer, value)); }
-    
+
     //contigs
     vector<long long> getOStart() { return (getValues(ostartPosition)); } //contigs overlap start - returns vector of 8 locations. (min, 2.5, 25, 50, 75, 97.5, max, mean)
     long long getOStart(double value) { return (getValue(ostartPosition, value)); } //contigs overlap start - 2.5 = 2.5% of sequences of sequences start before, 25 = location 25% of sequences start before
@@ -63,13 +63,13 @@ public:
     long long getScores(double value) { return (getValue(scores, value)); }
     vector<long long> getNumInserts() { return (getValues(inserts)); } //returns vector of 8 locations. (min, 2.5, 25, 50, 75, 97.5, max, mean)
     long long getNumInserts(double value) { return (getValue(inserts, value)); } //25 = max abigous bases 25% of sequences contain
+		int getMaxAbundance();
 
-    
     long long getTotalSeqs() { return total; }
     long long getUniqueSeqs() { return numUniques; }
-    
+
 private:
-    
+
     MothurOut* m;
     Utils util;
     int processors;
@@ -93,7 +93,7 @@ private:
     map<string, int> nameMap;
     map<string, int>::iterator itFindName;
     map<int, long long>::iterator it;
-    
+
     void processNameCount(string n); //determines whether name or count and fills nameMap, ignored if n = ""
     vector<long long> getValues(map<int, long long>& positions);
     long long getValue(map<int, long long>& positions, double);
@@ -102,7 +102,7 @@ private:
     bool isCountFile(string);
 
 
-    
+
 };
 /**************************************************************************************************/
 struct seqSumData {
@@ -130,8 +130,8 @@ struct seqSumData {
     bool hasNameMap;
     map<string, int> nameMap;
     Utils util;
-    
-    
+
+
     seqSumData(){}
     //FastaSummarize - output file created
     seqSumData(string f, string sum, unsigned long long st, unsigned long long en, bool na, map<string, int> nam) {
@@ -145,7 +145,7 @@ struct seqSumData {
         total = 0;
         summaryFile = sum;
     }
-    
+
     //FastaSummarySummarize - no output files
     seqSumData(string f, unsigned long long st, unsigned long long en, bool na, map<string, int> nam) {
         filename = f;


### PR DESCRIPTION
* Rebranded original algorithm as the `simple` algorithm. Also required the abundance of the merged sequence to be less than the parent sequence. Previously it was less than or equal to the parent sequence.
* Added `tree` algorithm, which allows sequences to merge if they are one off of a more abundant sequence. Retains the relationship between sequences so sequences that are N nt apart may merge if there is evidence that the N-1 version was the parent of the N version.
* Added `unoise` algorithm, which largely recreates the unoise denoising algorithm
* Added `deblur` algorithm, which implements the deblur algorithm without the database screening, alignment, and chimera checking. Also allows user to use a user-supplied error distribution or to specify `binomial` to assume the error distribution follows a binomial distribution following the average error rate, which the user can also set