### PR TITLE
Adds accnos parameter to cluster.fit

### DIFF
--- a/source/commands/clusterfitcommand.hpp
+++ b/source/commands/clusterfitcommand.hpp
@@ -46,7 +46,7 @@ public:
 private:
     bool abort, sim, print_start, selfReference, printref;
     string refdistfile, reffastafile, refnamefile, refcountfile, reflistfile, refNameOrCount;
-    string namefile, refformat, distfile, countfile, fastafile, columnfile, nameOrCount;
+    string namefile, refformat, distfile, countfile, fastafile, columnfile, nameOrCount, accnosfile;
     string comboDistFile;
     
     string method, fileroot, tag, outputDir, inputDir, metric, initialize, metricName, criteria, refWeight;
@@ -56,11 +56,13 @@ private:
     vector<string> outputNames, listFiles;
     unsigned long loops;
     
+    ListVector* runUserRefOptiCluster(OptiData*&, ClusterMetric*&, map<string, int>&, string);
     string runRefOptiCluster(OptiData*&, ClusterMetric*&, ListVector*&, map<string, int>&, string);
     string runDenovoOptiCluster(OptiData*&, ClusterMetric*&, map<string, int>&, string);
     ListVector* clusterRefs(OptiData*& refsMatrix, ClusterMetric*&);
     void createReferenceNameCount();
     string calcDists();
+    string runSensSpec(OptiData*& matrix, ClusterMetric*& userMetric, ListVector*& list, map<string, int>& counts);
     string runSensSpec(string distFileName, string dupsFile, string dupsFormat, ClusterMetric*&, string);
     void outputSteps(string outputName, bool& printHeaders, long long tp, long long tn, long long fp, long long fn, vector<double> results, long long numBins, long long fittp, long long fittn, long long fitfp, long long fitfn, vector<double> fitresults, long long numFitBins, int, bool, int);
 };

--- a/source/datastructures/optirefmatrix.hpp
+++ b/source/datastructures/optirefmatrix.hpp
@@ -24,6 +24,7 @@ public:
 #endif
     
     OptiRefMatrix(string, string, string, string, double, float, string); //distfile, distFormat, dupsFile, dupsFormat, cutoff, percentage to be fitseqs, refWeightMethod (options: abundance, none, connectivity)
+    OptiRefMatrix(string, string, string, string, double, string); //distfile, distFormat, dupsFile, dupsFormat, cutoff, accnosfile containing refNames
     OptiRefMatrix(string, string, string, string, double, string, string, string, string, string, string); //refdistfile, refname or refcount, refformat, refdistformat, cutoff, fitdistfile, fitname or fitcount, fitformat, fitdistformat, betweendistfile, betweendistformat - files for reference
     ~OptiRefMatrix(){ }
     
@@ -64,7 +65,7 @@ protected:
     int readPhylip(string distFile, bool hasName, map<string, string>& names, map<string, long long>& nameAssignment, map<long long, long long>& singletonIndexSwap);
     int readColumn(string distFile, bool hasName, map<string, string>& names, map<string, long long>& nameAssignment, map<long long, long long>& singletonIndexSwap);
     int readFiles(string, string, string, string, string, string, string, string, string, string, string, string);
-    int readFiles(string, string, string, string);
+    int readFiles(string, string, string, string, set<string>&);
     
     map<long long, long long> readColumnSingletons(vector<bool>& singleton, string distFile, map<string, long long>&);
     map<long long, long long> readPhylipSingletons(vector<bool>& singleton, string distFile, long long&,  map<string, long long>& nameAssignment);

--- a/source/sensspeccalc.cpp
+++ b/source/sensspeccalc.cpp
@@ -60,7 +60,7 @@ void SensSpecCalc::getResults(OptiData& matrix, long long& tp, long long& tn, lo
             }
         }
         long long numSeqs = matrix.getNumSeqs() + matrix.getNumSingletons();
-        long long numDists = matrix.getNumDists(); //square matrix
+        long long numDists = matrix.OptiData::getNumDists(); //square matrix OptiData:: uses the parent class function so that we can pass a optiref matrix
         
         fn = (numDists/2) - tp;
         tn = numSeqs * (numSeqs-1)/2  - (fp + fn + tp);


### PR DESCRIPTION
The accnos parameter allows you to assign reference sequences by name. This can save time by allowing you to provide a distance matrix containing all the sequence distances rather than a sample matrix and reference matrix and mothur calculating the distances between the sample and reference.

#415