### PR TITLE
align.seqs: Share AlignmentDB between threads

### DIFF
--- a/source/commands/aligncommand.cpp
+++ b/source/commands/aligncommand.cpp
@@ -244,27 +244,17 @@ AlignCommand::AlignCommand(string option)  {
 	}
 }
 //**********************************************************************************************************************
-AlignCommand::~AlignCommand(){}
+AlignCommand::~AlignCommand(){
+	if (!abort) { delete templateDB; }
+}
 //**********************************************************************************************************************
 
 int AlignCommand::execute(){
 	try {
 		if (abort) { if (calledHelp) { return 0; }  return 2;	}
-        
-        long long before = util.getRAMUsed(); long long total = util.getTotalRAM();
-        
-        if (m->getDebug()) { m->mothurOut("[DEBUG]: RAM used before reading template " + toString(before) + " of total RAM available " + toString(total) + "\n"); }
-        
-		AlignmentDB* templateDB; templateDB = new AlignmentDB(templateFileName, search, kmerSize, gapOpen, gapExtend, match, misMatch, util.getRandomNumber(), true);
-        long long after = util.getRAMUsed();
-        int numTemplatthatcanfitinMEM = total / ((after-before)*1.25);
-        
-        if (m->getDebug()) { m->mothurOut("[DEBUG]: RAM used after reading template " + toString(after) + ". Difference of " + toString(after-before) + "\n\nNumber of templates that can fit in memory " + toString(numTemplatthatcanfitinMEM) + "\n"); }
-        
-        if ((numTemplatthatcanfitinMEM < 1) || (numTemplatthatcanfitinMEM > processors)) {}
-        else if (numTemplatthatcanfitinMEM < processors) {  m->mothurOut("[WARNING]: You don't have enough RAM to run align.seqs with " + toString(processors) + " processors, reducing processors to " + toString(numTemplatthatcanfitinMEM) + ".\n"); processors = numTemplatthatcanfitinMEM; }
-        
-        delete templateDB;
+
+		templateDB = new AlignmentDB(templateFileName, search, kmerSize, gapOpen, gapExtend, match, misMatch, util.getRandomNumber(), true);
+
         if (m->getControl_pressed()) { outputTypes.clear(); return 0; }
         
         time_t start = time(NULL);
@@ -324,19 +314,19 @@ struct alignStruct {
     OutputWriter* reportWriter;
     OutputWriter* accnosWriter;
     string inputFilename;
-    string alignMethod, search, templateFileName;
+    string alignMethod, search;
     float match, misMatch, gapOpen, gapExtend, threshold;
     bool flip;
     long long numSeqs;
-    int kmerSize;
     
     vector<long long> flippedResults;
     linePair filePos;
     
     MothurOut* m;
+    AlignmentDB* templateDB;
     Utils util;
     
-       alignStruct (linePair fP, OutputWriter* aFName, OutputWriter* reFName, OutputWriter* ac, string fname, string tfn, string al, float ma, float misMa, float gOpen, float gExtend, float thr, bool fl, int ks, string se) {
+       alignStruct (linePair fP, OutputWriter* aFName, OutputWriter* reFName, OutputWriter* ac, string fname, string al, float ma, float misMa, float gOpen, float gExtend, float thr, bool fl, AlignmentDB* tB, string se) {
         
         filePos.start = fP.start;
         filePos.end = fP.end;
@@ -344,7 +334,6 @@ struct alignStruct {
         reportWriter = reFName;
         accnosWriter = ac;
         inputFilename = fname;
-        templateFileName = tfn;
         numSeqs = 0;
         m = MothurOut::getInstance();
         alignMethod = al;
@@ -354,8 +343,8 @@ struct alignStruct {
         gapExtend = gExtend;
         threshold = thr;
         flip = fl;
+        templateDB = tB;
         search = se;
-        kmerSize = ks;
         flippedResults.resize(2, 0);
     }
     
@@ -363,9 +352,6 @@ struct alignStruct {
 //**********************************************************************************************************************
 void alignDriver(alignStruct* params) {
 	try {
-        AlignmentDB* templateDB;
-        templateDB = new AlignmentDB(params->templateFileName, params->search, params->kmerSize, params->gapOpen, params->gapExtend, params->match, params->misMatch, params->util.getRandomNumber(), false);
-        
         NastReport report;
 		
 		ifstream inFASTA;
@@ -381,7 +367,7 @@ void alignDriver(alignStruct* params) {
 		
 		//moved this into driver to avoid deep copies in windows paralellized version
 		Alignment* alignment;
-		int longestBase = templateDB->getLongestBase();
+		int longestBase = params->templateDB->getLongestBase();
         if (params->m->getDebug()) { params->m->mothurOut("[DEBUG]: template longest base = "  + toString(longestBase) + " \n"); }
 		if(params->alignMethod == "gotoh")			{	alignment = new GotohOverlap(params->gapOpen, params->gapExtend, params->match, params->misMatch, longestBase);			}
 		else if(params->alignMethod == "needleman")	{	alignment = new NeedlemanOverlap(params->gapOpen, params->match, params->misMatch, longestBase);				}
@@ -411,7 +397,7 @@ void alignDriver(alignStruct* params) {
 				}
                 
                 float searchScore;
-				Sequence temp = templateDB->findClosestSequence(candidateSeq, searchScore);
+				Sequence temp = params->templateDB->findClosestSequence(candidateSeq, searchScore);
 				Sequence* templateSeq = new Sequence(temp.getName(), temp.getAligned());
 								
 				Nast* nast = new Nast(alignment, candidateSeq, templateSeq);
@@ -438,7 +424,7 @@ void alignDriver(alignStruct* params) {
                         if (params->m->getDebug()) { params->m->mothurOut("[DEBUG]: flipping "  + candidateSeq->getName() + " \n"); }
 						
 						//rerun alignment
-						Sequence temp2 = templateDB->findClosestSequence(copy, searchScore);
+						Sequence temp2 = params->templateDB->findClosestSequence(copy, searchScore);
 						Sequence* templateSeq2 = new Sequence(temp2.getName(), temp2.getAligned());
                         
                         if (params->m->getDebug()) { params->m->mothurOut("[DEBUG]: closest template "  + temp2.getName() + " \n"); }
@@ -504,7 +490,6 @@ void alignDriver(alignStruct* params) {
         params->flippedResults[1] += numFlipped_1;
         
 		delete alignment;
-        delete templateDB;
 		inFASTA.close();
 		
 	}
@@ -561,7 +546,8 @@ long long AlignCommand::createProcesses(string alignFileName, string reportFileN
             OutputWriter* threadAccnosWriter = new OutputWriter(synchronizedOutputAccnosFile);
 
             
-            alignStruct* dataBundle = new alignStruct(lines[i+1], threadAlignWriter, threadReportWriter, threadAccnosWriter, filename, templateFileName, align, match, misMatch, gapOpen, gapExtend, threshold, flip, kmerSize, search);
+            alignStruct* dataBundle = new alignStruct(lines[i+1], threadAlignWriter, threadReportWriter, threadAccnosWriter, filename,
+                                                        align, match, misMatch, gapOpen, gapExtend, threshold, flip, templateDB, search);
             data.push_back(dataBundle);
 
             workerThreads.push_back(new std::thread(alignDriver, dataBundle));
@@ -571,7 +557,8 @@ long long AlignCommand::createProcesses(string alignFileName, string reportFileN
         OutputWriter* threadReportWriter = new OutputWriter(synchronizedOutputReportFile);
         OutputWriter* threadAccnosWriter = new OutputWriter(synchronizedOutputAccnosFile);
         
-        alignStruct* dataBundle = new alignStruct(lines[0], threadAlignWriter, threadReportWriter, threadAccnosWriter, filename, templateFileName, align, match, misMatch, gapOpen, gapExtend, threshold, flip, kmerSize, search);
+        alignStruct* dataBundle = new alignStruct(lines[0], threadAlignWriter, threadReportWriter, threadAccnosWriter, filename,
+                                                  align, match, misMatch, gapOpen, gapExtend, threshold, flip, templateDB, search);
         alignDriver(dataBundle);
         numFlipped[0] = dataBundle->flippedResults[0];
         numFlipped[1] = dataBundle->flippedResults[1];

--- a/source/commands/aligncommand.h
+++ b/source/commands/aligncommand.h
@@ -47,7 +47,8 @@ public:
 	void help() { m->mothurOut(getHelpString()); }	
 	
 protected:
-	
+	AlignmentDB* templateDB;
+
 	long long createProcesses(string, string, string, string, vector<long long>&);
 	void appendReportFiles(string, string);
 		

--- a/source/datastructures/blastdb.hpp
+++ b/source/datastructures/blastdb.hpp
@@ -33,6 +33,7 @@ private:
 	string queryFileName;
 	string blastFileName;
 	string path;
+    std::mutex mutex;
 	
 	int count, threadID;
 	float gapOpen;

--- a/source/datastructures/database.hpp
+++ b/source/datastructures/database.hpp
@@ -67,7 +67,6 @@ protected:
 	MothurOut* m;
     CurrentFile* current;
 	int numSeqs, longest;
-    std::mutex mutex;
     Utils util;
 	
 	

--- a/source/datastructures/distancedb.cpp
+++ b/source/datastructures/distancedb.cpp
@@ -63,7 +63,6 @@ vector<int> DistanceDB::findClosestSequences(Sequence* query, int numWanted, vec
 			numWanted = data.size();
 		}
 		
-        lock_guard<std::mutex> guard(mutex);
 		if (sequence.length() != templateSeqsLength) { templateSameLength = false; }
 		
 		if (templateSameLength && templateAligned) {


### PR DESCRIPTION
As best as I can tell, `findClosestSequences` in `DistanceDB`, `KmerDB` and `SuffixDB` doesn't mutate state, `findClosestSequences` could be declared const in general if not for the `util.getRandomNumber();` call in `BlastDB`.

Cursory testing with `KmerDB` suggests `align.seqs` results are unchanged, with speed comparable to `v1.39.5`, and without substantially scaling RAM usage per thread.