### PR TITLE
fix pre.cluster empty output bug

### DIFF
--- a/source/commands/preclustercommand.cpp
+++ b/source/commands/preclustercommand.cpp
@@ -763,6 +763,7 @@ void print(string newfasta, string newname, preClusterData* params){
             for (int i = 0; i < params->alignSeqs.size(); i++) {
                 if (params->alignSeqs[i]->numIdentical != 0) {
                     ct.push_back(params->alignSeqs[i]->name, params->alignSeqs[i]->numIdentical);
+                    accnosNames.insert(params->alignSeqs[i]->name);
                 }
             }
         }


### PR DESCRIPTION
fixes #846 

This bug has symptom that the command `pre.cluster` may result in an empty fasta output.

This bug seems to be caused by passing an empty sequence name set to the fasta writer, affecting version 1.48.0, 1.48.1 as well as the master branch at the time.

The fix is to populate the sequence name set with sequence ids passed precluster before using it with the fasta writer, changed file source/commands/preclustercommand.cpp:line 766.