### PR TITLE
Fix linux/makefile compilation issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,8 +109,8 @@ endif
     subdirs :=  $(sort $(dir $(filter-out  $(skipUchime), $(wildcard source/*/))))
     subDirIncludes = $(patsubst %, -I %, $(subdirs))
     subDirLinking =  $(patsubst %, -L%, $(subdirs))
-    CXXFLAGS += -I. -I./source $(subDirIncludes)
-    LDFLAGS += $(subDirLinking)
+    CXXFLAGS += -I. -Isource/ $(subDirIncludes)
+    LDFLAGS += -Lsource/ $(subDirLinking)
 
 
 #
@@ -118,6 +118,8 @@ endif
 #
     OBJECTS=$(patsubst %.cpp,%.o,$(wildcard $(addsuffix *.cpp,$(subdirs))))
     OBJECTS+=$(patsubst %.c,%.o,$(wildcard $(addsuffix *.c,$(subdirs))))
+    OBJECTS+=$(patsubst %.cpp,%.o,$(wildcard source/*.cpp))
+    OBJECTS+=$(patsubst %.cpp,%.o,$(wildcard source/*.c))
     OBJECTS+=$(patsubst %.cpp,%.o,$(wildcard *.cpp))
     OBJECTS+=$(patsubst %.c,%.o,$(wildcard *.c))
 

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ endif
     subdirs :=  $(sort $(dir $(filter-out  $(skipUchime), $(wildcard source/*/))))
     subDirIncludes = $(patsubst %, -I %, $(subdirs))
     subDirLinking =  $(patsubst %, -L%, $(subdirs))
-    CXXFLAGS += -I. $(subDirIncludes)
+    CXXFLAGS += -I. -I./source $(subDirIncludes)
     LDFLAGS += $(subDirLinking)
 
 
@@ -135,7 +135,7 @@ else
 	mv mothur ${INSTALL_DIR}/mothur
 endif
 
-	
+
 %.o : %.c %.h
 	$(COMPILE.c) $(OUTPUT_OPTION) $<
 %.o : %.cpp %.h
@@ -147,4 +147,4 @@ endif
 
 clean :
 	@rm -f $(OBJECTS)
-	
+


### PR DESCRIPTION
These patches should fix two issues that I noticed, when trying to build `mothur`: 
- there was a complaint when using `gcc` that a certain header was not found.
- certain files were not built and linked against.

I'm not sure what the workflow is for building `mothur`, but I've tried to keep my
changes as minimal as possible as to not be disruptive.  Let me know if there are
any issues!