### PR TITLE
Fix Mothur compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,8 +109,8 @@ endif
     subdirs :=  $(sort $(dir $(filter-out  $(skipUchime), $(wildcard source/*/))))
     subDirIncludes = $(patsubst %, -I %, $(subdirs))
     subDirLinking =  $(patsubst %, -L%, $(subdirs))
-    CXXFLAGS += -I. $(subDirIncludes)
-    LDFLAGS += $(subDirLinking)
+    CXXFLAGS += -I. -Isource $(subDirIncludes)
+    LDFLAGS += -Lsource $(subDirLinking)
 
 
 #
@@ -120,6 +120,8 @@ endif
     OBJECTS+=$(patsubst %.c,%.o,$(wildcard $(addsuffix *.c,$(subdirs))))
     OBJECTS+=$(patsubst %.cpp,%.o,$(wildcard *.cpp))
     OBJECTS+=$(patsubst %.c,%.o,$(wildcard *.c))
+    OBJECTS+=$(patsubst %.cpp,%.o,$(wildcard source/*.cpp))
+    OBJECTS+=$(patsubst %.cpp,%.o,$(wildcard source/*.c))
 
 mothur : $(OBJECTS) uchime
 	$(CXX) $(LDFLAGS) $(TARGET_ARCH) -o $@ $(OBJECTS) $(LIBS)

--- a/source/uchime_src/makefile
+++ b/source/uchime_src/makefile
@@ -1,4 +1,4 @@
-CXXFLAGS = -O3 -D_FILE_OFFSET_BITS=64 -DNDEBUG=1 -DUCHIMES=1
+CXXFLAGS = -O3 -D_FILE_OFFSET_BITS=64 -DNDEBUG=1 -DUCHIMES=1 -std=c++11
 LDFLAGS = -g
 
 #
@@ -26,4 +26,4 @@ install : uchime
 
 clean :
 	@rm -f $(OBJECTS)
-	
+


### PR DESCRIPTION
Allow one to run : `make` from the root directory. Includes the source directory and missing objects.
Set c++11 standard to avoid clash with `byte` already defined in more recent version.

For example:
```
make -j 16 OPTIMIZE=yes USEREADLINE=yes USEBOOST=yes USEHDF5=yes USEGSL=yes BOOST_LIBRARY_DIR=$EBROOTBOOST/lib BOOST_INCLUDE_DIR=$EBROOTBOOST/include HDF5_LIBRARY_DIR=$EBROOTHDF5/lib HDF5_INCLUDE_DIR=$EBROOTHDF5/include GSL_LIBRARY_DIR=$EBROOTGSL/lib GSL_INCLUDE_DIR=$EBROOTGSL/include
```